### PR TITLE
eg01-eg23 and eg01-eg24 with d3ploy

### DIFF
--- a/input/eg01-eg23/flatpower_d3ploy.py
+++ b/input/eg01-eg23/flatpower_d3ploy.py
@@ -6,6 +6,7 @@ The user can choose a demand equation (demand_eq) and a buffer size
 (buff_size). The buffer plays its role one time step before the transition
 starts. The transition starts at after 960 time steps (80 years).
 """
+
 import json
 import re
 import subprocess
@@ -26,7 +27,8 @@ direc = os.listdir('./')
 ENV = dict(os.environ)
 ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
 
-calc_methods = ["ma", "arma", "arch", "poly", "exp_smoothing", "holt_winters", "fft", "sw_seasonal"]
+calc_methods = ["ma", "arma", "arch", "poly", "exp_smoothing", "holt_winters",
+                "fft", "sw_seasonal"]
 
 demand_eq = "60000"
 buff_size = "2000"
@@ -325,7 +327,7 @@ control = """
                         <item>
                             <commodity>lwrpu</commodity>
                             <pref>1.0</pref>
-                        </item>          
+                        </item>
                     </commodities>
                 </stream>
                 <stream>
@@ -337,7 +339,7 @@ control = """
                         <item>
                             <commodity>lwru</commodity>
                             <pref>1.0</pref>
-                        </item>                    
+                        </item>
                     </commodities>
                 </stream>
                 <stream>
@@ -374,7 +376,7 @@ control = """
                         <item>
                             <commodity>frpu</commodity>
                             <pref>1.0</pref>
-                        </item>          
+                        </item>
                     </commodities>
                 </stream>
                 <stream>
@@ -386,7 +388,7 @@ control = """
                         <item>
                             <commodity>fru</commodity>
                             <pref>1.0</pref>
-                        </item>                    
+                        </item>
                     </commodities>
                 </stream>
                 <stream>
@@ -441,291 +443,291 @@ recipes = """
     <nuclide> <id>U235</id> <comp>0.711</comp> </nuclide>
     <nuclide> <id>U238</id> <comp>99.289</comp> </nuclide>
 </recipe>
- 
+
 <recipe>
     <name>lwrinrecipe</name>
     <basis>mass</basis>
-    <nuclide> <id>U234</id>  <comp>0.0002558883</comp> </nuclide> 
-    <nuclide> <id>U235</id>  <comp>0.0319885317</comp> </nuclide> 
-    <nuclide> <id>U238</id>  <comp>0.96775558</comp> </nuclide> 
-</recipe> 
+    <nuclide> <id>U234</id>  <comp>0.0002558883</comp> </nuclide>
+    <nuclide> <id>U235</id>  <comp>0.0319885317</comp> </nuclide>
+    <nuclide> <id>U238</id>  <comp>0.96775558</comp> </nuclide>
+</recipe>
 
 <recipe>
     <name>lwroutrecipe</name>
     <basis>mass</basis>
-    <nuclide> <id>He4</id>  <comp>9.47457840128509E-07</comp> </nuclide> 
-    <nuclide> <id>Ra226</id>  <comp>9.78856442957042E-14</comp> </nuclide> 
-    <nuclide> <id>Ra228</id>  <comp>2.75087759176098E-20</comp> </nuclide> 
-    <nuclide> <id>Pb206</id>  <comp>5.57475193532078E-18</comp> </nuclide> 
-    <nuclide> <id>Pb207</id>  <comp>1.68592497990149E-15</comp> </nuclide> 
-    <nuclide> <id>Pb208</id>  <comp>3.6888358546006E-12</comp> </nuclide> 
-    <nuclide> <id>Pb210</id>  <comp>3.02386544437848E-19</comp> </nuclide> 
-    <nuclide> <id>Th228</id>  <comp>8.47562285269577E-12</comp> </nuclide> 
-    <nuclide> <id>Th229</id>  <comp>2.72787861516683E-12</comp> </nuclide> 
-    <nuclide> <id>Th230</id>  <comp>2.6258831537493E-09</comp> </nuclide> 
-    <nuclide> <id>Th232</id>  <comp>4.17481422959E-10</comp> </nuclide> 
-    <nuclide> <id>Bi209</id>  <comp>6.60770597104927E-16</comp> </nuclide> 
-    <nuclide> <id>Ac227</id>  <comp>3.0968621961773E-14</comp> </nuclide> 
-    <nuclide> <id>Pa231</id>  <comp>9.24658854635179E-10</comp> </nuclide> 
-    <nuclide> <id>U232</id>  <comp>0.000000001</comp> </nuclide> 
-    <nuclide> <id>U233</id>  <comp>2.21390148606282E-09</comp> </nuclide> 
-    <nuclide> <id>U234</id>  <comp>0.0001718924</comp> </nuclide> 
-    <nuclide> <id>U235</id>  <comp>0.0076486597</comp> </nuclide> 
-    <nuclide> <id>U236</id>  <comp>0.0057057461</comp> </nuclide> 
-    <nuclide> <id>U238</id>  <comp>0.9208590237</comp> </nuclide> 
-    <nuclide> <id>Np237</id>  <comp>0.0006091729</comp> </nuclide> 
-    <nuclide> <id>Pu238</id>  <comp>0.000291487</comp> </nuclide> 
-    <nuclide> <id>Pu239</id>  <comp>0.0060657301</comp> </nuclide> 
-    <nuclide> <id>Pu240</id>  <comp>0.0029058707</comp> </nuclide> 
-    <nuclide> <id>Pu241</id>  <comp>0.0017579218</comp> </nuclide> 
-    <nuclide> <id>Pu242</id>  <comp>0.0008638616</comp> </nuclide> 
-    <nuclide> <id>Pu244</id>  <comp>2.86487251922763E-08</comp> </nuclide> 
-    <nuclide> <id>Am241</id>  <comp>6.44271331287386E-05</comp> </nuclide> 
-    <nuclide> <id>Am242m</id>  <comp>8.53362027193319E-07</comp> </nuclide> 
-    <nuclide> <id>Am243</id>  <comp>0.0001983912</comp> </nuclide> 
-    <nuclide> <id>Cm242</id>  <comp>2.58988475560194E-05</comp> </nuclide> 
-    <nuclide> <id>Cm243</id>  <comp>0.000000771</comp> </nuclide> 
-    <nuclide> <id>Cm244</id>  <comp>8.5616190260478E-05</comp> </nuclide> 
-    <nuclide> <id>Cm245</id>  <comp>5.72174539442251E-06</comp> </nuclide> 
-    <nuclide> <id>Cm246</id>  <comp>7.29567535786554E-07</comp> </nuclide> 
-    <nuclide> <id>Cm247</id>  <comp>0.00000001</comp> </nuclide> 
-    <nuclide> <id>Cm248</id>  <comp>7.69165773748653E-10</comp> </nuclide> 
-    <nuclide> <id>Cm250</id>  <comp>4.2808095130239E-18</comp> </nuclide> 
-    <nuclide> <id>Cf249</id>  <comp>1.64992658175413E-12</comp> </nuclide> 
-    <nuclide> <id>Cf250</id>  <comp>2.04190913935875E-12</comp> </nuclide> 
-    <nuclide> <id>Cf251</id>  <comp>9.86556100338561E-13</comp> </nuclide> 
-    <nuclide> <id>Cf252</id>  <comp>6.57970721693466E-13</comp> </nuclide> 
-    <nuclide> <id>H3</id>  <comp>8.58461800264195E-08</comp> </nuclide> 
-    <nuclide> <id>C14</id>  <comp>4.05781943561107E-11</comp> </nuclide> 
-    <nuclide> <id>Kr81</id>  <comp>4.21681236076192E-11</comp> </nuclide> 
-    <nuclide> <id>Kr85</id>  <comp>3.44484671160181E-05</comp> </nuclide> 
-    <nuclide> <id>Sr90</id>  <comp>0.0007880649</comp> </nuclide> 
-    <nuclide> <id>Tc99</id>  <comp>0.0011409492</comp> </nuclide> 
-    <nuclide> <id>I129</id>  <comp>0.0002731878</comp> </nuclide> 
-    <nuclide> <id>Cs134</id>  <comp>0.0002300898</comp> </nuclide> 
-    <nuclide> <id>Cs135</id>  <comp>0.0006596706</comp> </nuclide> 
-    <nuclide> <id>Cs137</id>  <comp>0.0018169192</comp> </nuclide> 
-    <nuclide> <id>H1</id>  <comp>0.0477938151</comp> </nuclide> 
-</recipe> 
+    <nuclide> <id>He4</id>  <comp>9.47457840128509E-07</comp> </nuclide>
+    <nuclide> <id>Ra226</id>  <comp>9.78856442957042E-14</comp> </nuclide>
+    <nuclide> <id>Ra228</id>  <comp>2.75087759176098E-20</comp> </nuclide>
+    <nuclide> <id>Pb206</id>  <comp>5.57475193532078E-18</comp> </nuclide>
+    <nuclide> <id>Pb207</id>  <comp>1.68592497990149E-15</comp> </nuclide>
+    <nuclide> <id>Pb208</id>  <comp>3.6888358546006E-12</comp> </nuclide>
+    <nuclide> <id>Pb210</id>  <comp>3.02386544437848E-19</comp> </nuclide>
+    <nuclide> <id>Th228</id>  <comp>8.47562285269577E-12</comp> </nuclide>
+    <nuclide> <id>Th229</id>  <comp>2.72787861516683E-12</comp> </nuclide>
+    <nuclide> <id>Th230</id>  <comp>2.6258831537493E-09</comp> </nuclide>
+    <nuclide> <id>Th232</id>  <comp>4.17481422959E-10</comp> </nuclide>
+    <nuclide> <id>Bi209</id>  <comp>6.60770597104927E-16</comp> </nuclide>
+    <nuclide> <id>Ac227</id>  <comp>3.0968621961773E-14</comp> </nuclide>
+    <nuclide> <id>Pa231</id>  <comp>9.24658854635179E-10</comp> </nuclide>
+    <nuclide> <id>U232</id>  <comp>0.000000001</comp> </nuclide>
+    <nuclide> <id>U233</id>  <comp>2.21390148606282E-09</comp> </nuclide>
+    <nuclide> <id>U234</id>  <comp>0.0001718924</comp> </nuclide>
+    <nuclide> <id>U235</id>  <comp>0.0076486597</comp> </nuclide>
+    <nuclide> <id>U236</id>  <comp>0.0057057461</comp> </nuclide>
+    <nuclide> <id>U238</id>  <comp>0.9208590237</comp> </nuclide>
+    <nuclide> <id>Np237</id>  <comp>0.0006091729</comp> </nuclide>
+    <nuclide> <id>Pu238</id>  <comp>0.000291487</comp> </nuclide>
+    <nuclide> <id>Pu239</id>  <comp>0.0060657301</comp> </nuclide>
+    <nuclide> <id>Pu240</id>  <comp>0.0029058707</comp> </nuclide>
+    <nuclide> <id>Pu241</id>  <comp>0.0017579218</comp> </nuclide>
+    <nuclide> <id>Pu242</id>  <comp>0.0008638616</comp> </nuclide>
+    <nuclide> <id>Pu244</id>  <comp>2.86487251922763E-08</comp> </nuclide>
+    <nuclide> <id>Am241</id>  <comp>6.44271331287386E-05</comp> </nuclide>
+    <nuclide> <id>Am242m</id>  <comp>8.53362027193319E-07</comp> </nuclide>
+    <nuclide> <id>Am243</id>  <comp>0.0001983912</comp> </nuclide>
+    <nuclide> <id>Cm242</id>  <comp>2.58988475560194E-05</comp> </nuclide>
+    <nuclide> <id>Cm243</id>  <comp>0.000000771</comp> </nuclide>
+    <nuclide> <id>Cm244</id>  <comp>8.5616190260478E-05</comp> </nuclide>
+    <nuclide> <id>Cm245</id>  <comp>5.72174539442251E-06</comp> </nuclide>
+    <nuclide> <id>Cm246</id>  <comp>7.29567535786554E-07</comp> </nuclide>
+    <nuclide> <id>Cm247</id>  <comp>0.00000001</comp> </nuclide>
+    <nuclide> <id>Cm248</id>  <comp>7.69165773748653E-10</comp> </nuclide>
+    <nuclide> <id>Cm250</id>  <comp>4.2808095130239E-18</comp> </nuclide>
+    <nuclide> <id>Cf249</id>  <comp>1.64992658175413E-12</comp> </nuclide>
+    <nuclide> <id>Cf250</id>  <comp>2.04190913935875E-12</comp> </nuclide>
+    <nuclide> <id>Cf251</id>  <comp>9.86556100338561E-13</comp> </nuclide>
+    <nuclide> <id>Cf252</id>  <comp>6.57970721693466E-13</comp> </nuclide>
+    <nuclide> <id>H3</id>  <comp>8.58461800264195E-08</comp> </nuclide>
+    <nuclide> <id>C14</id>  <comp>4.05781943561107E-11</comp> </nuclide>
+    <nuclide> <id>Kr81</id>  <comp>4.21681236076192E-11</comp> </nuclide>
+    <nuclide> <id>Kr85</id>  <comp>3.44484671160181E-05</comp> </nuclide>
+    <nuclide> <id>Sr90</id>  <comp>0.0007880649</comp> </nuclide>
+    <nuclide> <id>Tc99</id>  <comp>0.0011409492</comp> </nuclide>
+    <nuclide> <id>I129</id>  <comp>0.0002731878</comp> </nuclide>
+    <nuclide> <id>Cs134</id>  <comp>0.0002300898</comp> </nuclide>
+    <nuclide> <id>Cs135</id>  <comp>0.0006596706</comp> </nuclide>
+    <nuclide> <id>Cs137</id>  <comp>0.0018169192</comp> </nuclide>
+    <nuclide> <id>H1</id>  <comp>0.0477938151</comp> </nuclide>
+</recipe>
 
 <recipe>
     <name>frinrecipe</name>
     <basis>mass</basis>
-    <nuclide> <id>U234</id>  <comp>9.7224110389438E-05</comp> </nuclide> 
-    <nuclide> <id>U235</id>  <comp>0.0039469814</comp> </nuclide> 
-    <nuclide> <id>U236</id>  <comp>0.0021573569</comp> </nuclide> 
-    <nuclide> <id>U238</id>  <comp>0.8665733427</comp> </nuclide> 
-    <nuclide> <id>Np237</id>  <comp>0.0060565044</comp> </nuclide> 
-    <nuclide> <id>Pu238</id>  <comp>0.0030040068</comp> </nuclide> 
-    <nuclide> <id>Pu239</id>  <comp>0.0606135352</comp> </nuclide> 
-    <nuclide> <id>Pu240</id>  <comp>0.0286774758</comp> </nuclide> 
-    <nuclide> <id>Pu241</id>  <comp>0.0134998465</comp> </nuclide> 
-    <nuclide> <id>Pu242</id>  <comp>0.0084034605</comp> </nuclide> 
-    <nuclide> <id>Am241</id>  <comp>0.0042991968</comp> </nuclide> 
-    <nuclide> <id>Am242m</id>  <comp>7.73428708584307E-06</comp> </nuclide> 
-    <nuclide> <id>Am243</id>  <comp>0.0019207217</comp> </nuclide> 
-    <nuclide> <id>Cm243</id>  <comp>6.47352555460846E-06</comp> </nuclide> 
-    <nuclide> <id>Cm244</id>  <comp>0.0006812961</comp> </nuclide> 
-    <nuclide> <id>Cm245</id>  <comp>5.48431266087054E-05</comp> </nuclide> 
-    <nuclide> <id>H1</id>  <comp>0</comp> </nuclide> 
+    <nuclide> <id>U234</id>  <comp>9.7224110389438E-05</comp> </nuclide>
+    <nuclide> <id>U235</id>  <comp>0.0039469814</comp> </nuclide>
+    <nuclide> <id>U236</id>  <comp>0.0021573569</comp> </nuclide>
+    <nuclide> <id>U238</id>  <comp>0.8665733427</comp> </nuclide>
+    <nuclide> <id>Np237</id>  <comp>0.0060565044</comp> </nuclide>
+    <nuclide> <id>Pu238</id>  <comp>0.0030040068</comp> </nuclide>
+    <nuclide> <id>Pu239</id>  <comp>0.0606135352</comp> </nuclide>
+    <nuclide> <id>Pu240</id>  <comp>0.0286774758</comp> </nuclide>
+    <nuclide> <id>Pu241</id>  <comp>0.0134998465</comp> </nuclide>
+    <nuclide> <id>Pu242</id>  <comp>0.0084034605</comp> </nuclide>
+    <nuclide> <id>Am241</id>  <comp>0.0042991968</comp> </nuclide>
+    <nuclide> <id>Am242m</id>  <comp>7.73428708584307E-06</comp> </nuclide>
+    <nuclide> <id>Am243</id>  <comp>0.0019207217</comp> </nuclide>
+    <nuclide> <id>Cm243</id>  <comp>6.47352555460846E-06</comp> </nuclide>
+    <nuclide> <id>Cm244</id>  <comp>0.0006812961</comp> </nuclide>
+    <nuclide> <id>Cm245</id>  <comp>5.48431266087054E-05</comp> </nuclide>
+    <nuclide> <id>H1</id>  <comp>0</comp> </nuclide>
 </recipe>
 
 <recipe>
     <name>froutrecipe</name>
     <basis>mass</basis>
-    <nuclide> <id>H1</id>  <comp>2.1237926533769418e-06</comp> </nuclide> 
-    <nuclide> <id>H1</id>  <comp>2.1237926533769418e-06</comp> </nuclide> 
-    <nuclide> <id>H2</id>  <comp>6.506416799362884e-07</comp> </nuclide> 
-    <nuclide> <id>H3</id>  <comp>8.716143259523863e-06</comp> </nuclide> 
-    <nuclide> <id>He3</id>  <comp>8.716143259523863e-06</comp> </nuclide> 
-    <nuclide> <id>He4</id>  <comp>0.0001344250263264596</comp> </nuclide> 
-    <nuclide> <id>Br85</id>  <comp>0.00037872256275536787</comp> </nuclide> 
-    <nuclide> <id>Kr82</id>  <comp>3.375970980801497e-07</comp> </nuclide> 
-    <nuclide> <id>Kr85</id>  <comp>8.470618097283756e-05</comp> </nuclide> 
-    <nuclide> <id>Kr85m</id>  <comp>0.00037872256275536787</comp> </nuclide> 
-    <nuclide> <id>Sr90</id>  <comp>0.0012466540112741529</comp> </nuclide> 
-    <nuclide> <id>Zr95</id>  <comp>0.002873872024020474</comp> </nuclide> 
-    <nuclide> <id>Nb94</id>  <comp>1.565222909280694e-09</comp> </nuclide> 
-    <nuclide> <id>Nb95</id>  <comp>0.0028726443982092734</comp> </nuclide> 
-    <nuclide> <id>Nb95m</id>  <comp>3.105893302337377e-05</comp> </nuclide> 
-    <nuclide> <id>Mo94</id>  <comp>2.946301946881306e-12</comp> </nuclide> 
-    <nuclide> <id>Mo96</id>  <comp>1.0434819395204624e-06</comp> </nuclide> 
-    <nuclide> <id>Mo99</id>  <comp>0.003572391110593584</comp> </nuclide> 
-    <nuclide> <id>Tc99</id>  <comp>0.003572391110593584</comp> </nuclide> 
-    <nuclide> <id>Ru103</id>  <comp>0.0040450270479057936</comp> </nuclide> 
-    <nuclide> <id>Ru106</id>  <comp>0.0025350473001291237</comp> </nuclide> 
-    <nuclide> <id>Rh106</id>  <comp>0.0025350473001291237</comp> </nuclide> 
-    <nuclide> <id>Sn121m</id>  <comp>3.2532083996814424e-06</comp> </nuclide> 
-    <nuclide> <id>Sb122</id>  <comp>9.391337455684162e-09</comp> </nuclide> 
-    <nuclide> <id>Sb124</id>  <comp>9.45271874624419e-07</comp> </nuclide> 
-    <nuclide> <id>Sb125</id>  <comp>8.470618097283756e-05</comp> </nuclide> 
-    <nuclide> <id>Te132</id>  <comp>0.003019959495553339</comp> </nuclide> 
-    <nuclide> <id>I129</id>  <comp>0.0008040949063363564</comp> </nuclide> 
-    <nuclide> <id>I131</id>  <comp>0.002510494783905113</comp> </nuclide> 
-    <nuclide> <id>I133</id>  <comp>0.004290552210145902</comp> </nuclide> 
-    <nuclide> <id>I135</id>  <comp>0.003830192530945698</comp> </nuclide> 
-    <nuclide> <id>Xe128</id>  <comp>1.5345322640006803e-09</comp> </nuclide> 
-    <nuclide> <id>Xe130</id>  <comp>1.4179078119366286e-06</comp> </nuclide> 
-    <nuclide> <id>Xe131m</id>  <comp>2.7253293008652085e-05</comp> </nuclide> 
-    <nuclide> <id>Xe133</id>  <comp>0.004315104726369913</comp> </nuclide> 
-    <nuclide> <id>Xe133m</id>  <comp>0.00013688027794886068</comp> </nuclide> 
-    <nuclide> <id>Xe135</id>  <comp>0.004603596792002041</comp> </nuclide> 
-    <nuclide> <id>Xe135m</id>  <comp>0.001209211424032536</comp> </nuclide> 
-    <nuclide> <id>Cs134</id>  <comp>7.05884841440313e-07</comp> </nuclide> 
-    <nuclide> <id>Cs137</id>  <comp>0.003897711950561728</comp> </nuclide> 
-    <nuclide> <id>Ba140</id>  <comp>0.003255049838398243</comp> </nuclide> 
-    <nuclide> <id>La140</id>  <comp>0.0032679399094158487</comp> </nuclide> 
-    <nuclide> <id>Ce141</id>  <comp>0.0030752026570573633</comp> </nuclide> 
-    <nuclide> <id>Ce144</id>  <comp>0.0021508004212233535</comp> </nuclide> 
-    <nuclide> <id>Pr144</id>  <comp>0.002151414234128954</comp> </nuclide> 
-    <nuclide> <id>Nd142</id>  <comp>1.540670393056683e-09</comp> </nuclide> 
-    <nuclide> <id>Nd144</id>  <comp>0.002151414234128954</comp> </nuclide> 
-    <nuclide> <id>Nd147</id>  <comp>0.001184045094902925</comp> </nuclide> 
-    <nuclide> <id>Pm147</id>  <comp>0.001184045094902925</comp> </nuclide> 
-    <nuclide> <id>Pm148</id>  <comp>7.365754867203266e-09</comp> </nuclide> 
-    <nuclide> <id>Pm148m</id>  <comp>1.780057426240789e-08</comp> </nuclide> 
-    <nuclide> <id>Pm149</id>  <comp>0.0007826114546403469</comp> </nuclide> 
-    <nuclide> <id>Pm151</id>  <comp>0.0004885950728578165</comp> </nuclide> 
-    <nuclide> <id>Sm148</id>  <comp>2.3938703318410615e-08</comp> </nuclide> 
-    <nuclide> <id>Sm150</id>  <comp>3.130445818561388e-06</comp> </nuclide> 
-    <nuclide> <id>Sm151</id>  <comp>0.0004892088857634169</comp> </nuclide> 
-    <nuclide> <id>Sm153</id>  <comp>0.00024552516224010884</comp> </nuclide> 
-    <nuclide> <id>Eu151</id>  <comp>0.0004892088857634169</comp> </nuclide> 
-    <nuclide> <id>Eu152</id>  <comp>2.9463019468813056e-10</comp> </nuclide> 
-    <nuclide> <id>Eu154</id>  <comp>7.795423901123456e-08</comp> </nuclide> 
-    <nuclide> <id>Eu155</id>  <comp>0.00010496200685764655</comp> </nuclide> 
-    <nuclide> <id>Pu238</id>  <comp>0.00109335928440193</comp> </nuclide> 
-    <nuclide> <id>Pu239</id>  <comp>0.0930067275743179</comp> </nuclide> 
-    <nuclide> <id>Pu240</id>  <comp>0.030500623501972753</comp> </nuclide> 
-    <nuclide> <id>Pu241</id>  <comp>0.0034020252053028497</comp> </nuclide> 
-    <nuclide> <id>Pu242</id>  <comp>0.00170935846724797</comp> </nuclide> 
-    <nuclide> <id>Pu244</id>  <comp>5.9667566e-09</comp> </nuclide> 
-    <nuclide> <id>U232</id>  <comp>7.764620174645652e-09</comp> </nuclide> 
-    <nuclide> <id>U233</id>  <comp>5.365956105805943e-09</comp> </nuclide> 
-    <nuclide> <id>U234</id>  <comp>0.00015792257454093998</comp> </nuclide> 
-    <nuclide> <id>U235</id>  <comp>0.00019371425185969997</comp> </nuclide> 
-    <nuclide> <id>U236</id>  <comp>0.00030462860329308</comp> </nuclide> 
-    <nuclide> <id>U238</id>  <comp>0.7843763214602618</comp> </nuclide> 
-    <nuclide> <id>Am241</id>  <comp>0.0051501477520177</comp> </nuclide> 
-    <nuclide> <id>Am242m</id>  <comp>0.000335357136931</comp> </nuclide> 
-    <nuclide> <id>Am243</id>  <comp>0.0015164335378926998</comp> </nuclide> 
-    <nuclide> <id>Cm242</id>  <comp>0.00022459089899389998</comp> </nuclide> 
-    <nuclide> <id>Cm243</id>  <comp>1.3657049394099997e-05</comp> </nuclide> 
-    <nuclide> <id>Cm244</id>  <comp>0.0007493459387043999</comp> </nuclide> 
-    <nuclide> <id>Cm245</id>  <comp>0.00016582831469939997</comp> </nuclide> 
-    <nuclide> <id>Cm246</id>  <comp>6.0434845141199995e-05</comp> </nuclide> 
-    <nuclide> <id>Cm247</id>  <comp>2.2397642322999996e-06</comp> </nuclide> 
-    <nuclide> <id>Cm248</id>  <comp>1.6006247130135967e-07</comp> </nuclide> 
-    <nuclide> <id>Cm250</id>  <comp>2.6991508458592675e-14</comp> </nuclide> 
-    <nuclide> <id>Cf249</id>  <comp>2.7154845877404104e-09</comp> </nuclide> 
-    <nuclide> <id>Cf250</id>  <comp>2.823695627703007e-10</comp> </nuclide> 
-    <nuclide> <id>Cf251</id>  <comp>8.017825545907209e-12</comp> </nuclide> 
-    <nuclide> <id>Cf252</id>  <comp>1.691154800019082e-13</comp> </nuclide> 
-    <nuclide> <id>Np237</id>  <comp>0.0029948016924556</comp> </nuclide> 
+    <nuclide> <id>H1</id>  <comp>2.1237926533769418e-06</comp> </nuclide>
+    <nuclide> <id>H1</id>  <comp>2.1237926533769418e-06</comp> </nuclide>
+    <nuclide> <id>H2</id>  <comp>6.506416799362884e-07</comp> </nuclide>
+    <nuclide> <id>H3</id>  <comp>8.716143259523863e-06</comp> </nuclide>
+    <nuclide> <id>He3</id>  <comp>8.716143259523863e-06</comp> </nuclide>
+    <nuclide> <id>He4</id>  <comp>0.0001344250263264596</comp> </nuclide>
+    <nuclide> <id>Br85</id>  <comp>0.00037872256275536787</comp> </nuclide>
+    <nuclide> <id>Kr82</id>  <comp>3.375970980801497e-07</comp> </nuclide>
+    <nuclide> <id>Kr85</id>  <comp>8.470618097283756e-05</comp> </nuclide>
+    <nuclide> <id>Kr85m</id>  <comp>0.00037872256275536787</comp> </nuclide>
+    <nuclide> <id>Sr90</id>  <comp>0.0012466540112741529</comp> </nuclide>
+    <nuclide> <id>Zr95</id>  <comp>0.002873872024020474</comp> </nuclide>
+    <nuclide> <id>Nb94</id>  <comp>1.565222909280694e-09</comp> </nuclide>
+    <nuclide> <id>Nb95</id>  <comp>0.0028726443982092734</comp> </nuclide>
+    <nuclide> <id>Nb95m</id>  <comp>3.105893302337377e-05</comp> </nuclide>
+    <nuclide> <id>Mo94</id>  <comp>2.946301946881306e-12</comp> </nuclide>
+    <nuclide> <id>Mo96</id>  <comp>1.0434819395204624e-06</comp> </nuclide>
+    <nuclide> <id>Mo99</id>  <comp>0.003572391110593584</comp> </nuclide>
+    <nuclide> <id>Tc99</id>  <comp>0.003572391110593584</comp> </nuclide>
+    <nuclide> <id>Ru103</id>  <comp>0.0040450270479057936</comp> </nuclide>
+    <nuclide> <id>Ru106</id>  <comp>0.0025350473001291237</comp> </nuclide>
+    <nuclide> <id>Rh106</id>  <comp>0.0025350473001291237</comp> </nuclide>
+    <nuclide> <id>Sn121m</id>  <comp>3.2532083996814424e-06</comp> </nuclide>
+    <nuclide> <id>Sb122</id>  <comp>9.391337455684162e-09</comp> </nuclide>
+    <nuclide> <id>Sb124</id>  <comp>9.45271874624419e-07</comp> </nuclide>
+    <nuclide> <id>Sb125</id>  <comp>8.470618097283756e-05</comp> </nuclide>
+    <nuclide> <id>Te132</id>  <comp>0.003019959495553339</comp> </nuclide>
+    <nuclide> <id>I129</id>  <comp>0.0008040949063363564</comp> </nuclide>
+    <nuclide> <id>I131</id>  <comp>0.002510494783905113</comp> </nuclide>
+    <nuclide> <id>I133</id>  <comp>0.004290552210145902</comp> </nuclide>
+    <nuclide> <id>I135</id>  <comp>0.003830192530945698</comp> </nuclide>
+    <nuclide> <id>Xe128</id>  <comp>1.5345322640006803e-09</comp> </nuclide>
+    <nuclide> <id>Xe130</id>  <comp>1.4179078119366286e-06</comp> </nuclide>
+    <nuclide> <id>Xe131m</id>  <comp>2.7253293008652085e-05</comp> </nuclide>
+    <nuclide> <id>Xe133</id>  <comp>0.004315104726369913</comp> </nuclide>
+    <nuclide> <id>Xe133m</id>  <comp>0.00013688027794886068</comp> </nuclide>
+    <nuclide> <id>Xe135</id>  <comp>0.004603596792002041</comp> </nuclide>
+    <nuclide> <id>Xe135m</id>  <comp>0.001209211424032536</comp> </nuclide>
+    <nuclide> <id>Cs134</id>  <comp>7.05884841440313e-07</comp> </nuclide>
+    <nuclide> <id>Cs137</id>  <comp>0.003897711950561728</comp> </nuclide>
+    <nuclide> <id>Ba140</id>  <comp>0.003255049838398243</comp> </nuclide>
+    <nuclide> <id>La140</id>  <comp>0.0032679399094158487</comp> </nuclide>
+    <nuclide> <id>Ce141</id>  <comp>0.0030752026570573633</comp> </nuclide>
+    <nuclide> <id>Ce144</id>  <comp>0.0021508004212233535</comp> </nuclide>
+    <nuclide> <id>Pr144</id>  <comp>0.002151414234128954</comp> </nuclide>
+    <nuclide> <id>Nd142</id>  <comp>1.540670393056683e-09</comp> </nuclide>
+    <nuclide> <id>Nd144</id>  <comp>0.002151414234128954</comp> </nuclide>
+    <nuclide> <id>Nd147</id>  <comp>0.001184045094902925</comp> </nuclide>
+    <nuclide> <id>Pm147</id>  <comp>0.001184045094902925</comp> </nuclide>
+    <nuclide> <id>Pm148</id>  <comp>7.365754867203266e-09</comp> </nuclide>
+    <nuclide> <id>Pm148m</id>  <comp>1.780057426240789e-08</comp> </nuclide>
+    <nuclide> <id>Pm149</id>  <comp>0.0007826114546403469</comp> </nuclide>
+    <nuclide> <id>Pm151</id>  <comp>0.0004885950728578165</comp> </nuclide>
+    <nuclide> <id>Sm148</id>  <comp>2.3938703318410615e-08</comp> </nuclide>
+    <nuclide> <id>Sm150</id>  <comp>3.130445818561388e-06</comp> </nuclide>
+    <nuclide> <id>Sm151</id>  <comp>0.0004892088857634169</comp> </nuclide>
+    <nuclide> <id>Sm153</id>  <comp>0.00024552516224010884</comp> </nuclide>
+    <nuclide> <id>Eu151</id>  <comp>0.0004892088857634169</comp> </nuclide>
+    <nuclide> <id>Eu152</id>  <comp>2.9463019468813056e-10</comp> </nuclide>
+    <nuclide> <id>Eu154</id>  <comp>7.795423901123456e-08</comp> </nuclide>
+    <nuclide> <id>Eu155</id>  <comp>0.00010496200685764655</comp> </nuclide>
+    <nuclide> <id>Pu238</id>  <comp>0.00109335928440193</comp> </nuclide>
+    <nuclide> <id>Pu239</id>  <comp>0.0930067275743179</comp> </nuclide>
+    <nuclide> <id>Pu240</id>  <comp>0.030500623501972753</comp> </nuclide>
+    <nuclide> <id>Pu241</id>  <comp>0.0034020252053028497</comp> </nuclide>
+    <nuclide> <id>Pu242</id>  <comp>0.00170935846724797</comp> </nuclide>
+    <nuclide> <id>Pu244</id>  <comp>5.9667566e-09</comp> </nuclide>
+    <nuclide> <id>U232</id>  <comp>7.764620174645652e-09</comp> </nuclide>
+    <nuclide> <id>U233</id>  <comp>5.365956105805943e-09</comp> </nuclide>
+    <nuclide> <id>U234</id>  <comp>0.00015792257454093998</comp> </nuclide>
+    <nuclide> <id>U235</id>  <comp>0.00019371425185969997</comp> </nuclide>
+    <nuclide> <id>U236</id>  <comp>0.00030462860329308</comp> </nuclide>
+    <nuclide> <id>U238</id>  <comp>0.7843763214602618</comp> </nuclide>
+    <nuclide> <id>Am241</id>  <comp>0.0051501477520177</comp> </nuclide>
+    <nuclide> <id>Am242m</id>  <comp>0.000335357136931</comp> </nuclide>
+    <nuclide> <id>Am243</id>  <comp>0.0015164335378926998</comp> </nuclide>
+    <nuclide> <id>Cm242</id>  <comp>0.00022459089899389998</comp> </nuclide>
+    <nuclide> <id>Cm243</id>  <comp>1.3657049394099997e-05</comp> </nuclide>
+    <nuclide> <id>Cm244</id>  <comp>0.0007493459387043999</comp> </nuclide>
+    <nuclide> <id>Cm245</id>  <comp>0.00016582831469939997</comp> </nuclide>
+    <nuclide> <id>Cm246</id>  <comp>6.0434845141199995e-05</comp> </nuclide>
+    <nuclide> <id>Cm247</id>  <comp>2.2397642322999996e-06</comp> </nuclide>
+    <nuclide> <id>Cm248</id>  <comp>1.6006247130135967e-07</comp> </nuclide>
+    <nuclide> <id>Cm250</id>  <comp>2.6991508458592675e-14</comp> </nuclide>
+    <nuclide> <id>Cf249</id>  <comp>2.7154845877404104e-09</comp> </nuclide>
+    <nuclide> <id>Cf250</id>  <comp>2.823695627703007e-10</comp> </nuclide>
+    <nuclide> <id>Cf251</id>  <comp>8.017825545907209e-12</comp> </nuclide>
+    <nuclide> <id>Cf252</id>  <comp>1.691154800019082e-13</comp> </nuclide>
+    <nuclide> <id>Np237</id>  <comp>0.0029948016924556</comp> </nuclide>
 </recipe>
 """
 
 region = {}
 
 for calc_method in calc_methods:
-    region[calc_method]= """
+    region[calc_method] = """
     <region>
         <config>
             <NullRegion>
             </NullRegion>
         </config>
 
-        <institution> 
+        <institution>
             <name>lwr_inst</name>
             <config>
             <DeployInst>
             <prototypes>
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
                 <val>lwr</val>
-                <val>lwr</val> 
                 <val>lwr</val>
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
             </prototypes> 
             <build_times>
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
                 <val>1</val>
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-            </build_times> 
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+            </build_times>
             <n_build>
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-            </n_build> 
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+            </n_build>
             <lifetimes>
-                <val>960</val> 
-                <val>970</val> 
-                <val>980</val> 
-                <val>990</val> 
-                <val>1000</val> 
-                <val>1010</val> 
-                <val>1020</val> 
-                <val>1030</val> 
-                <val>1040</val> 
+                <val>960</val>
+                <val>970</val>
+                <val>980</val>
+                <val>990</val>
+                <val>1000</val>
+                <val>1010</val>
+                <val>1020</val>
+                <val>1030</val>
+                <val>1040</val>
                 <val>1050</val>
-                <val>1060</val> 
-                <val>1070</val> 
-                <val>1080</val> 
-                <val>1090</val> 
-                <val>1100</val> 
-                <val>1110</val> 
-                <val>1120</val> 
-                <val>1130</val> 
-                <val>1140</val> 
-                <val>1150</val> 
+                <val>1060</val>
+                <val>1070</val>
+                <val>1080</val>
+                <val>1090</val>
+                <val>1100</val>
+                <val>1110</val>
+                <val>1120</val>
+                <val>1130</val>
+                <val>1140</val>
+                <val>1150</val>
             </lifetimes>
             </DeployInst>
             </config>
@@ -754,7 +756,7 @@ for calc_method in calc_methods:
             <item>
               <facility>source</facility>
               <capacity>1e9</capacity>
-            </item>    
+            </item>
             <item>
               <facility>enrichment</facility>
               <capacity>1e100</capacity>
@@ -866,12 +868,14 @@ for calc_method in calc_methods:
 
         <name>SingleRegion</name>
     </region>
-    """%(calc_method, demand_eq, buff_size, calc_method)
+    """ % (calc_method, demand_eq, buff_size, calc_method)
 
 for calc_method in calc_methods:
 
-    input_file = 'eg01-eg23-flatpower-d3ploy-buffer' + buff_size + '-' + calc_method + '.xml'
-    output_file = 'eg01-eg23-flatpower-d3ploy-buffer' + buff_size + '-' + calc_method + '.sqlite'
+    input_file = 'eg01-eg23-flatpower-d3ploy-buffer' + buff_size + '-' \
+                + calc_method + '.xml'
+    output_file = 'eg01-eg23-flatpower-d3ploy-buffer' + buff_size + '-' \
+                + calc_method + '.sqlite'
 
     with open(input_file, 'w') as f:
         f.write('<simulation>\n')
@@ -881,4 +885,4 @@ for calc_method in calc_methods:
         f.write('</simulation>')
 
     s = subprocess.check_output(['cyclus', '-o', output_file, input_file],
-                            universal_newlines=True, env=ENV)
+                                universal_newlines=True, env=ENV)

--- a/input/eg01-eg23/flatpower_d3ploy.py
+++ b/input/eg01-eg23/flatpower_d3ploy.py
@@ -873,9 +873,9 @@ for calc_method in calc_methods:
 for calc_method in calc_methods:
 
     input_file = 'eg01-eg23-flatpower-d3ploy-buffer' + buff_size + '-' \
-                + calc_method + '.xml'
+        + calc_method + '.xml'
     output_file = 'eg01-eg23-flatpower-d3ploy-buffer' + buff_size + '-' \
-            + calc_method + '.sqlite'
+        + calc_method + '.sqlite'
 
     with open(input_file, 'w') as f:
         f.write('<simulation>\n')

--- a/input/eg01-eg23/flatpower_d3ploy.py
+++ b/input/eg01-eg23/flatpower_d3ploy.py
@@ -775,7 +775,7 @@ for calc_method in calc_methods:
             <buffer_type>
             <item>
               <commod>POWER</commod>
-              <type>float</type>
+              <type>abs</type>
             </item>
             </buffer_type>
             <supply_buffer>

--- a/input/eg01-eg23/flatpower_d3ploy.py
+++ b/input/eg01-eg23/flatpower_d3ploy.py
@@ -1,0 +1,884 @@
+"""
+Running this script generates .xml files and runs them producing the .sqlite
+files for all the prediction methods.
+
+The user can choose a demand equation (demand_eq) and a buffer size
+(buff_size). The buffer plays its role one time step before the transition
+starts. The transition starts at after 960 time steps (80 years).
+"""
+import json
+import re
+import subprocess
+import os
+import sqlite3 as lite
+import copy
+import glob
+import sys
+from matplotlib import pyplot as plt
+import numpy as np
+import pandas as pd
+import d3ploy.tester as tester
+import d3ploy.plotter as plotter
+import collections
+
+direc = os.listdir('./')
+
+ENV = dict(os.environ)
+ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
+
+calc_methods = ["ma", "arma", "arch", "poly", "exp_smoothing", "holt_winters", "fft", "sw_seasonal"]
+
+demand_eq = "60000"
+buff_size = "2000"
+
+control = """
+<control>
+    <duration>1440</duration>
+    <startmonth>1</startmonth>
+    <startyear>2000</startyear>
+    <decay>lazy</decay>
+</control>
+
+<archetypes>
+        <spec>
+            <lib>cycamore</lib>
+            <name>Source</name>
+        </spec>
+        <spec>
+            <lib>cycamore</lib>
+            <name>Enrichment</name>
+        </spec>
+        <spec>
+            <lib>cycamore</lib>
+            <name>Reactor</name>
+        </spec>
+        <spec>
+            <lib>cycamore</lib>
+            <name>Storage</name>
+        </spec>
+        <spec>
+            <lib>cycamore</lib>
+            <name>Separations</name>
+        </spec>
+        <spec>
+            <lib>cycamore</lib>
+            <name>Mixer</name>
+        </spec>
+        <spec>
+            <lib>cycamore</lib>
+            <name>Sink</name>
+        </spec>
+        <spec>
+            <lib>agents</lib>
+            <name>NullRegion</name>
+        </spec>
+        <spec>
+            <lib>agents</lib>
+            <name>NullInst</name>
+        </spec>
+        <spec>
+            <lib>cycamore</lib>
+            <name>DeployInst</name>
+        </spec>
+        <spec>
+            <lib>d3ploy.demand_driven_deployment_inst</lib>
+            <name>DemandDrivenDeploymentInst</name>
+        </spec>
+        <spec>
+            <lib>d3ploy.supply_driven_deployment_inst</lib>
+            <name>SupplyDrivenDeploymentInst</name>
+        </spec>
+</archetypes>
+
+<facility>
+    <name>source</name>
+    <config>
+        <Source>
+            <outcommod>sourceout</outcommod>
+            <outrecipe>sourceoutrecipe</outrecipe>
+            <throughput>1e9</throughput>
+        </Source>
+    </config>
+</facility>
+
+<facility>
+    <name>enrichment</name>
+    <config>
+        <Enrichment>
+            <feed_commod>sourceout</feed_commod>
+            <feed_recipe>sourceoutrecipe</feed_recipe>
+            <product_commod>enrichmentout</product_commod>
+            <tails_assay>0.0025</tails_assay>
+            <tails_commod>enrichmentwaste</tails_commod>
+            <swu_capacity>1e100</swu_capacity>
+            <initial_feed>5e7</initial_feed>
+            <max_feed_inventory>1e8</max_feed_inventory>
+        </Enrichment>
+    </config>
+</facility>
+
+<facility>
+    <name>lwr</name>
+    <config>
+        <Reactor>
+            <fuel_inrecipes>
+                <val>lwrinrecipe</val>
+            </fuel_inrecipes>
+            <fuel_outrecipes>
+                <val>lwroutrecipe</val>
+            </fuel_outrecipes>
+            <fuel_incommods>
+                <val>enrichmentout</val>
+            </fuel_incommods>
+            <fuel_outcommods>
+                <val>lwrout</val>
+            </fuel_outcommods>
+            <cycle_time>18</cycle_time>
+            <refuel_time>0</refuel_time>
+            <assem_size>29863.3</assem_size>
+            <n_assem_core>3</n_assem_core>
+            <n_assem_batch>1</n_assem_batch>
+            <power_cap>1000</power_cap>
+        </Reactor>
+    </config>
+</facility>
+
+<facility>
+    <name>lwr2</name>
+    <lifetime>960</lifetime>
+    <config>
+        <Reactor>
+            <fuel_inrecipes>
+                <val>lwrinrecipe</val>
+            </fuel_inrecipes>
+            <fuel_outrecipes>
+                <val>lwroutrecipe</val>
+            </fuel_outrecipes>
+            <fuel_incommods>
+                <val>enrichmentout</val>
+            </fuel_incommods>
+            <fuel_outcommods>
+                <val>lwrout</val>
+            </fuel_outcommods>
+            <cycle_time>18</cycle_time>
+            <refuel_time>0</refuel_time>
+            <assem_size>29863.3</assem_size>
+            <n_assem_core>3</n_assem_core>
+            <n_assem_batch>1</n_assem_batch>
+            <power_cap>1000</power_cap>
+        </Reactor>
+    </config>
+</facility>
+
+<facility>
+    <name>fr</name>
+    <lifetime>720</lifetime>
+    <config>
+        <Reactor>
+            <fuel_inrecipes>
+                <val>frinrecipe</val>
+            </fuel_inrecipes>
+            <fuel_outrecipes>
+                <val>froutrecipe</val>
+            </fuel_outrecipes>
+            <fuel_incommods>
+                <val>mixerout</val>
+            </fuel_incommods>
+            <fuel_outcommods>
+                <val>frout</val>
+            </fuel_outcommods>
+            <cycle_time>12</cycle_time>
+            <refuel_time>0</refuel_time>
+            <assem_size>5867</assem_size>
+            <n_assem_core>4</n_assem_core>
+            <n_assem_batch>1</n_assem_batch>
+            <power_cap>333.34</power_cap>
+        </Reactor>
+    </config>
+</facility>
+
+<facility>
+    <name>lwrstorage</name>
+    <config>
+        <Storage>
+            <in_commods>
+                <val>lwrout</val>
+            </in_commods>
+            <residence_time>36</residence_time>
+            <out_commods>
+                <val>lwrstorageout</val>
+            </out_commods>
+            <max_inv_size>1e7</max_inv_size>
+        </Storage>
+    </config>
+</facility>
+
+<facility>
+    <name>frstorage</name>
+    <config>
+        <Storage>
+            <in_commods>
+                <val>frout</val>
+            </in_commods>
+            <residence_time>36</residence_time>
+            <out_commods>
+                <val>frstorageout</val>
+            </out_commods>
+            <max_inv_size>1e7</max_inv_size>
+        </Storage>
+    </config>
+</facility>
+
+<facility>
+    <name>lwrreprocessing</name>
+    <config>
+        <Separations>
+            <feed_commods>
+                <val>lwrstorageout</val>
+            </feed_commods>
+            <feedbuf_size>1e8</feedbuf_size>
+            <throughput>1e8</throughput>
+            <leftover_commod>lwrreprocessingwaste</leftover_commod>
+            <leftoverbuf_size>1e8</leftoverbuf_size>
+            <streams>
+                <item>
+                    <commod>lwrpu</commod>
+                    <info>
+                        <buf_size>1e8</buf_size>
+                        <efficiencies>
+                            <item>
+                                <comp>Pu</comp>
+                                <eff>1.0</eff>
+                            </item>
+                        </efficiencies>
+                    </info>
+                </item>
+                <item>
+                    <commod>lwru</commod>
+                    <info>
+                        <buf_size>1e8</buf_size>
+                        <efficiencies>
+                            <item>
+                                <comp>U</comp>
+                                <eff>1.0</eff>
+                            </item>
+                        </efficiencies>
+                    </info>
+                </item>
+            </streams>
+        </Separations>
+    </config>
+</facility>
+
+<facility>
+    <name>frreprocessing</name>
+    <config>
+        <Separations>
+            <feed_commods>
+                <val>frstorageout</val>
+            </feed_commods>
+            <feedbuf_size>1e8</feedbuf_size>
+            <throughput>1e8</throughput>
+            <leftover_commod>frreprocessingwaste</leftover_commod>
+            <leftoverbuf_size>1e8</leftoverbuf_size>
+            <streams>
+                <item>
+                    <commod>frpu</commod>
+                    <info>
+                        <buf_size>1e8</buf_size>
+                        <efficiencies>
+                            <item>
+                                <comp>Pu</comp>
+                                <eff>1.0</eff>
+                            </item>
+                        </efficiencies>
+                    </info>
+                </item>
+                <item>
+                    <commod>fru</commod>
+                    <info>
+                        <buf_size>1e8</buf_size>
+                        <efficiencies>
+                            <item>
+                                <comp>U</comp>
+                                <eff>1.0</eff>
+                            </item>
+                        </efficiencies>
+                    </info>
+                </item>
+            </streams>
+        </Separations>
+    </config>
+</facility>
+
+<facility>
+    <name>lwrmixer</name>
+    <config>
+        <Mixer>
+            <in_streams>
+                <stream>
+                    <info>
+                        <mixing_ratio>0.129</mixing_ratio>
+                        <buf_size>1e6</buf_size>
+                    </info>
+                    <commodities>
+                        <item>
+                            <commodity>lwrpu</commodity>
+                            <pref>1.0</pref>
+                        </item>          
+                    </commodities>
+                </stream>
+                <stream>
+                    <info>
+                        <mixing_ratio>0.714</mixing_ratio>
+                        <buf_size>1e7</buf_size>
+                    </info>
+                    <commodities>
+                        <item>
+                            <commodity>lwru</commodity>
+                            <pref>1.0</pref>
+                        </item>                    
+                    </commodities>
+                </stream>
+                <stream>
+                    <info>
+                        <mixing_ratio>0.157</mixing_ratio>
+                        <buf_size>1e7</buf_size>
+                    </info>
+                    <commodities>
+                        <item>
+                            <commodity>sourceout</commodity>
+                            <pref>1.0</pref>
+                        </item>
+                    </commodities>
+                </stream>
+            </in_streams>
+            <out_commod>mixerout</out_commod>
+            <out_buf_size>1e10</out_buf_size>
+            <throughput>1e7</throughput>
+        </Mixer>
+    </config>
+</facility>
+
+<facility>
+    <name>frmixer</name>
+    <config>
+        <Mixer>
+            <in_streams>
+                <stream>
+                    <info>
+                        <mixing_ratio>0.129</mixing_ratio>
+                        <buf_size>1e6</buf_size>
+                    </info>
+                    <commodities>
+                        <item>
+                            <commodity>frpu</commodity>
+                            <pref>1.0</pref>
+                        </item>          
+                    </commodities>
+                </stream>
+                <stream>
+                    <info>
+                        <mixing_ratio>0.714</mixing_ratio>
+                        <buf_size>1e7</buf_size>
+                    </info>
+                    <commodities>
+                        <item>
+                            <commodity>fru</commodity>
+                            <pref>1.0</pref>
+                        </item>                    
+                    </commodities>
+                </stream>
+                <stream>
+                    <info>
+                        <mixing_ratio>0.157</mixing_ratio>
+                        <buf_size>1e7</buf_size>
+                    </info>
+                    <commodities>
+                        <item>
+                            <commodity>sourceout</commodity>
+                            <pref>1.0</pref>
+                        </item>
+                    </commodities>
+                </stream>
+            </in_streams>
+            <out_commod>mixerout</out_commod>
+            <out_buf_size>1e10</out_buf_size>
+            <throughput>1e7</throughput>
+        </Mixer>
+    </config>
+</facility>
+
+<facility>
+    <name>lwrsink</name>
+    <config>
+        <Sink>
+            <in_commods>
+                <val>lwrreprocessingwaste</val>
+            </in_commods>
+            <max_inv_size>1e10</max_inv_size>
+        </Sink>
+    </config>
+</facility>
+
+<facility>
+    <name>frsink</name>
+    <config>
+        <Sink>
+            <in_commods>
+                <val>frreprocessingwaste</val>
+            </in_commods>
+            <max_inv_size>1e10</max_inv_size>
+        </Sink>
+    </config>
+</facility>
+"""
+
+recipes = """
+<recipe>
+    <name>sourceoutrecipe</name>
+    <basis>mass</basis>
+    <nuclide> <id>U235</id> <comp>0.711</comp> </nuclide>
+    <nuclide> <id>U238</id> <comp>99.289</comp> </nuclide>
+</recipe>
+ 
+<recipe>
+    <name>lwrinrecipe</name>
+    <basis>mass</basis>
+    <nuclide> <id>U234</id>  <comp>0.0002558883</comp> </nuclide> 
+    <nuclide> <id>U235</id>  <comp>0.0319885317</comp> </nuclide> 
+    <nuclide> <id>U238</id>  <comp>0.96775558</comp> </nuclide> 
+</recipe> 
+
+<recipe>
+    <name>lwroutrecipe</name>
+    <basis>mass</basis>
+    <nuclide> <id>He4</id>  <comp>9.47457840128509E-07</comp> </nuclide> 
+    <nuclide> <id>Ra226</id>  <comp>9.78856442957042E-14</comp> </nuclide> 
+    <nuclide> <id>Ra228</id>  <comp>2.75087759176098E-20</comp> </nuclide> 
+    <nuclide> <id>Pb206</id>  <comp>5.57475193532078E-18</comp> </nuclide> 
+    <nuclide> <id>Pb207</id>  <comp>1.68592497990149E-15</comp> </nuclide> 
+    <nuclide> <id>Pb208</id>  <comp>3.6888358546006E-12</comp> </nuclide> 
+    <nuclide> <id>Pb210</id>  <comp>3.02386544437848E-19</comp> </nuclide> 
+    <nuclide> <id>Th228</id>  <comp>8.47562285269577E-12</comp> </nuclide> 
+    <nuclide> <id>Th229</id>  <comp>2.72787861516683E-12</comp> </nuclide> 
+    <nuclide> <id>Th230</id>  <comp>2.6258831537493E-09</comp> </nuclide> 
+    <nuclide> <id>Th232</id>  <comp>4.17481422959E-10</comp> </nuclide> 
+    <nuclide> <id>Bi209</id>  <comp>6.60770597104927E-16</comp> </nuclide> 
+    <nuclide> <id>Ac227</id>  <comp>3.0968621961773E-14</comp> </nuclide> 
+    <nuclide> <id>Pa231</id>  <comp>9.24658854635179E-10</comp> </nuclide> 
+    <nuclide> <id>U232</id>  <comp>0.000000001</comp> </nuclide> 
+    <nuclide> <id>U233</id>  <comp>2.21390148606282E-09</comp> </nuclide> 
+    <nuclide> <id>U234</id>  <comp>0.0001718924</comp> </nuclide> 
+    <nuclide> <id>U235</id>  <comp>0.0076486597</comp> </nuclide> 
+    <nuclide> <id>U236</id>  <comp>0.0057057461</comp> </nuclide> 
+    <nuclide> <id>U238</id>  <comp>0.9208590237</comp> </nuclide> 
+    <nuclide> <id>Np237</id>  <comp>0.0006091729</comp> </nuclide> 
+    <nuclide> <id>Pu238</id>  <comp>0.000291487</comp> </nuclide> 
+    <nuclide> <id>Pu239</id>  <comp>0.0060657301</comp> </nuclide> 
+    <nuclide> <id>Pu240</id>  <comp>0.0029058707</comp> </nuclide> 
+    <nuclide> <id>Pu241</id>  <comp>0.0017579218</comp> </nuclide> 
+    <nuclide> <id>Pu242</id>  <comp>0.0008638616</comp> </nuclide> 
+    <nuclide> <id>Pu244</id>  <comp>2.86487251922763E-08</comp> </nuclide> 
+    <nuclide> <id>Am241</id>  <comp>6.44271331287386E-05</comp> </nuclide> 
+    <nuclide> <id>Am242m</id>  <comp>8.53362027193319E-07</comp> </nuclide> 
+    <nuclide> <id>Am243</id>  <comp>0.0001983912</comp> </nuclide> 
+    <nuclide> <id>Cm242</id>  <comp>2.58988475560194E-05</comp> </nuclide> 
+    <nuclide> <id>Cm243</id>  <comp>0.000000771</comp> </nuclide> 
+    <nuclide> <id>Cm244</id>  <comp>8.5616190260478E-05</comp> </nuclide> 
+    <nuclide> <id>Cm245</id>  <comp>5.72174539442251E-06</comp> </nuclide> 
+    <nuclide> <id>Cm246</id>  <comp>7.29567535786554E-07</comp> </nuclide> 
+    <nuclide> <id>Cm247</id>  <comp>0.00000001</comp> </nuclide> 
+    <nuclide> <id>Cm248</id>  <comp>7.69165773748653E-10</comp> </nuclide> 
+    <nuclide> <id>Cm250</id>  <comp>4.2808095130239E-18</comp> </nuclide> 
+    <nuclide> <id>Cf249</id>  <comp>1.64992658175413E-12</comp> </nuclide> 
+    <nuclide> <id>Cf250</id>  <comp>2.04190913935875E-12</comp> </nuclide> 
+    <nuclide> <id>Cf251</id>  <comp>9.86556100338561E-13</comp> </nuclide> 
+    <nuclide> <id>Cf252</id>  <comp>6.57970721693466E-13</comp> </nuclide> 
+    <nuclide> <id>H3</id>  <comp>8.58461800264195E-08</comp> </nuclide> 
+    <nuclide> <id>C14</id>  <comp>4.05781943561107E-11</comp> </nuclide> 
+    <nuclide> <id>Kr81</id>  <comp>4.21681236076192E-11</comp> </nuclide> 
+    <nuclide> <id>Kr85</id>  <comp>3.44484671160181E-05</comp> </nuclide> 
+    <nuclide> <id>Sr90</id>  <comp>0.0007880649</comp> </nuclide> 
+    <nuclide> <id>Tc99</id>  <comp>0.0011409492</comp> </nuclide> 
+    <nuclide> <id>I129</id>  <comp>0.0002731878</comp> </nuclide> 
+    <nuclide> <id>Cs134</id>  <comp>0.0002300898</comp> </nuclide> 
+    <nuclide> <id>Cs135</id>  <comp>0.0006596706</comp> </nuclide> 
+    <nuclide> <id>Cs137</id>  <comp>0.0018169192</comp> </nuclide> 
+    <nuclide> <id>H1</id>  <comp>0.0477938151</comp> </nuclide> 
+</recipe> 
+
+<recipe>
+    <name>frinrecipe</name>
+    <basis>mass</basis>
+    <nuclide> <id>U234</id>  <comp>9.7224110389438E-05</comp> </nuclide> 
+    <nuclide> <id>U235</id>  <comp>0.0039469814</comp> </nuclide> 
+    <nuclide> <id>U236</id>  <comp>0.0021573569</comp> </nuclide> 
+    <nuclide> <id>U238</id>  <comp>0.8665733427</comp> </nuclide> 
+    <nuclide> <id>Np237</id>  <comp>0.0060565044</comp> </nuclide> 
+    <nuclide> <id>Pu238</id>  <comp>0.0030040068</comp> </nuclide> 
+    <nuclide> <id>Pu239</id>  <comp>0.0606135352</comp> </nuclide> 
+    <nuclide> <id>Pu240</id>  <comp>0.0286774758</comp> </nuclide> 
+    <nuclide> <id>Pu241</id>  <comp>0.0134998465</comp> </nuclide> 
+    <nuclide> <id>Pu242</id>  <comp>0.0084034605</comp> </nuclide> 
+    <nuclide> <id>Am241</id>  <comp>0.0042991968</comp> </nuclide> 
+    <nuclide> <id>Am242m</id>  <comp>7.73428708584307E-06</comp> </nuclide> 
+    <nuclide> <id>Am243</id>  <comp>0.0019207217</comp> </nuclide> 
+    <nuclide> <id>Cm243</id>  <comp>6.47352555460846E-06</comp> </nuclide> 
+    <nuclide> <id>Cm244</id>  <comp>0.0006812961</comp> </nuclide> 
+    <nuclide> <id>Cm245</id>  <comp>5.48431266087054E-05</comp> </nuclide> 
+    <nuclide> <id>H1</id>  <comp>0</comp> </nuclide> 
+</recipe>
+
+<recipe>
+    <name>froutrecipe</name>
+    <basis>mass</basis>
+    <nuclide> <id>H1</id>  <comp>2.1237926533769418e-06</comp> </nuclide> 
+    <nuclide> <id>H1</id>  <comp>2.1237926533769418e-06</comp> </nuclide> 
+    <nuclide> <id>H2</id>  <comp>6.506416799362884e-07</comp> </nuclide> 
+    <nuclide> <id>H3</id>  <comp>8.716143259523863e-06</comp> </nuclide> 
+    <nuclide> <id>He3</id>  <comp>8.716143259523863e-06</comp> </nuclide> 
+    <nuclide> <id>He4</id>  <comp>0.0001344250263264596</comp> </nuclide> 
+    <nuclide> <id>Br85</id>  <comp>0.00037872256275536787</comp> </nuclide> 
+    <nuclide> <id>Kr82</id>  <comp>3.375970980801497e-07</comp> </nuclide> 
+    <nuclide> <id>Kr85</id>  <comp>8.470618097283756e-05</comp> </nuclide> 
+    <nuclide> <id>Kr85m</id>  <comp>0.00037872256275536787</comp> </nuclide> 
+    <nuclide> <id>Sr90</id>  <comp>0.0012466540112741529</comp> </nuclide> 
+    <nuclide> <id>Zr95</id>  <comp>0.002873872024020474</comp> </nuclide> 
+    <nuclide> <id>Nb94</id>  <comp>1.565222909280694e-09</comp> </nuclide> 
+    <nuclide> <id>Nb95</id>  <comp>0.0028726443982092734</comp> </nuclide> 
+    <nuclide> <id>Nb95m</id>  <comp>3.105893302337377e-05</comp> </nuclide> 
+    <nuclide> <id>Mo94</id>  <comp>2.946301946881306e-12</comp> </nuclide> 
+    <nuclide> <id>Mo96</id>  <comp>1.0434819395204624e-06</comp> </nuclide> 
+    <nuclide> <id>Mo99</id>  <comp>0.003572391110593584</comp> </nuclide> 
+    <nuclide> <id>Tc99</id>  <comp>0.003572391110593584</comp> </nuclide> 
+    <nuclide> <id>Ru103</id>  <comp>0.0040450270479057936</comp> </nuclide> 
+    <nuclide> <id>Ru106</id>  <comp>0.0025350473001291237</comp> </nuclide> 
+    <nuclide> <id>Rh106</id>  <comp>0.0025350473001291237</comp> </nuclide> 
+    <nuclide> <id>Sn121m</id>  <comp>3.2532083996814424e-06</comp> </nuclide> 
+    <nuclide> <id>Sb122</id>  <comp>9.391337455684162e-09</comp> </nuclide> 
+    <nuclide> <id>Sb124</id>  <comp>9.45271874624419e-07</comp> </nuclide> 
+    <nuclide> <id>Sb125</id>  <comp>8.470618097283756e-05</comp> </nuclide> 
+    <nuclide> <id>Te132</id>  <comp>0.003019959495553339</comp> </nuclide> 
+    <nuclide> <id>I129</id>  <comp>0.0008040949063363564</comp> </nuclide> 
+    <nuclide> <id>I131</id>  <comp>0.002510494783905113</comp> </nuclide> 
+    <nuclide> <id>I133</id>  <comp>0.004290552210145902</comp> </nuclide> 
+    <nuclide> <id>I135</id>  <comp>0.003830192530945698</comp> </nuclide> 
+    <nuclide> <id>Xe128</id>  <comp>1.5345322640006803e-09</comp> </nuclide> 
+    <nuclide> <id>Xe130</id>  <comp>1.4179078119366286e-06</comp> </nuclide> 
+    <nuclide> <id>Xe131m</id>  <comp>2.7253293008652085e-05</comp> </nuclide> 
+    <nuclide> <id>Xe133</id>  <comp>0.004315104726369913</comp> </nuclide> 
+    <nuclide> <id>Xe133m</id>  <comp>0.00013688027794886068</comp> </nuclide> 
+    <nuclide> <id>Xe135</id>  <comp>0.004603596792002041</comp> </nuclide> 
+    <nuclide> <id>Xe135m</id>  <comp>0.001209211424032536</comp> </nuclide> 
+    <nuclide> <id>Cs134</id>  <comp>7.05884841440313e-07</comp> </nuclide> 
+    <nuclide> <id>Cs137</id>  <comp>0.003897711950561728</comp> </nuclide> 
+    <nuclide> <id>Ba140</id>  <comp>0.003255049838398243</comp> </nuclide> 
+    <nuclide> <id>La140</id>  <comp>0.0032679399094158487</comp> </nuclide> 
+    <nuclide> <id>Ce141</id>  <comp>0.0030752026570573633</comp> </nuclide> 
+    <nuclide> <id>Ce144</id>  <comp>0.0021508004212233535</comp> </nuclide> 
+    <nuclide> <id>Pr144</id>  <comp>0.002151414234128954</comp> </nuclide> 
+    <nuclide> <id>Nd142</id>  <comp>1.540670393056683e-09</comp> </nuclide> 
+    <nuclide> <id>Nd144</id>  <comp>0.002151414234128954</comp> </nuclide> 
+    <nuclide> <id>Nd147</id>  <comp>0.001184045094902925</comp> </nuclide> 
+    <nuclide> <id>Pm147</id>  <comp>0.001184045094902925</comp> </nuclide> 
+    <nuclide> <id>Pm148</id>  <comp>7.365754867203266e-09</comp> </nuclide> 
+    <nuclide> <id>Pm148m</id>  <comp>1.780057426240789e-08</comp> </nuclide> 
+    <nuclide> <id>Pm149</id>  <comp>0.0007826114546403469</comp> </nuclide> 
+    <nuclide> <id>Pm151</id>  <comp>0.0004885950728578165</comp> </nuclide> 
+    <nuclide> <id>Sm148</id>  <comp>2.3938703318410615e-08</comp> </nuclide> 
+    <nuclide> <id>Sm150</id>  <comp>3.130445818561388e-06</comp> </nuclide> 
+    <nuclide> <id>Sm151</id>  <comp>0.0004892088857634169</comp> </nuclide> 
+    <nuclide> <id>Sm153</id>  <comp>0.00024552516224010884</comp> </nuclide> 
+    <nuclide> <id>Eu151</id>  <comp>0.0004892088857634169</comp> </nuclide> 
+    <nuclide> <id>Eu152</id>  <comp>2.9463019468813056e-10</comp> </nuclide> 
+    <nuclide> <id>Eu154</id>  <comp>7.795423901123456e-08</comp> </nuclide> 
+    <nuclide> <id>Eu155</id>  <comp>0.00010496200685764655</comp> </nuclide> 
+    <nuclide> <id>Pu238</id>  <comp>0.00109335928440193</comp> </nuclide> 
+    <nuclide> <id>Pu239</id>  <comp>0.0930067275743179</comp> </nuclide> 
+    <nuclide> <id>Pu240</id>  <comp>0.030500623501972753</comp> </nuclide> 
+    <nuclide> <id>Pu241</id>  <comp>0.0034020252053028497</comp> </nuclide> 
+    <nuclide> <id>Pu242</id>  <comp>0.00170935846724797</comp> </nuclide> 
+    <nuclide> <id>Pu244</id>  <comp>5.9667566e-09</comp> </nuclide> 
+    <nuclide> <id>U232</id>  <comp>7.764620174645652e-09</comp> </nuclide> 
+    <nuclide> <id>U233</id>  <comp>5.365956105805943e-09</comp> </nuclide> 
+    <nuclide> <id>U234</id>  <comp>0.00015792257454093998</comp> </nuclide> 
+    <nuclide> <id>U235</id>  <comp>0.00019371425185969997</comp> </nuclide> 
+    <nuclide> <id>U236</id>  <comp>0.00030462860329308</comp> </nuclide> 
+    <nuclide> <id>U238</id>  <comp>0.7843763214602618</comp> </nuclide> 
+    <nuclide> <id>Am241</id>  <comp>0.0051501477520177</comp> </nuclide> 
+    <nuclide> <id>Am242m</id>  <comp>0.000335357136931</comp> </nuclide> 
+    <nuclide> <id>Am243</id>  <comp>0.0015164335378926998</comp> </nuclide> 
+    <nuclide> <id>Cm242</id>  <comp>0.00022459089899389998</comp> </nuclide> 
+    <nuclide> <id>Cm243</id>  <comp>1.3657049394099997e-05</comp> </nuclide> 
+    <nuclide> <id>Cm244</id>  <comp>0.0007493459387043999</comp> </nuclide> 
+    <nuclide> <id>Cm245</id>  <comp>0.00016582831469939997</comp> </nuclide> 
+    <nuclide> <id>Cm246</id>  <comp>6.0434845141199995e-05</comp> </nuclide> 
+    <nuclide> <id>Cm247</id>  <comp>2.2397642322999996e-06</comp> </nuclide> 
+    <nuclide> <id>Cm248</id>  <comp>1.6006247130135967e-07</comp> </nuclide> 
+    <nuclide> <id>Cm250</id>  <comp>2.6991508458592675e-14</comp> </nuclide> 
+    <nuclide> <id>Cf249</id>  <comp>2.7154845877404104e-09</comp> </nuclide> 
+    <nuclide> <id>Cf250</id>  <comp>2.823695627703007e-10</comp> </nuclide> 
+    <nuclide> <id>Cf251</id>  <comp>8.017825545907209e-12</comp> </nuclide> 
+    <nuclide> <id>Cf252</id>  <comp>1.691154800019082e-13</comp> </nuclide> 
+    <nuclide> <id>Np237</id>  <comp>0.0029948016924556</comp> </nuclide> 
+</recipe>
+"""
+
+region = {}
+
+for calc_method in calc_methods:
+    region[calc_method]= """
+    <region>
+        <config>
+            <NullRegion>
+            </NullRegion>
+        </config>
+
+        <institution> 
+            <name>lwr_inst</name>
+            <config>
+            <DeployInst>
+            <prototypes>
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val>
+                <val>lwr</val> 
+                <val>lwr</val>
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+            </prototypes> 
+            <build_times>
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val>
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+            </build_times> 
+            <n_build>
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+            </n_build> 
+            <lifetimes>
+                <val>960</val> 
+                <val>970</val> 
+                <val>980</val> 
+                <val>990</val> 
+                <val>1000</val> 
+                <val>1010</val> 
+                <val>1020</val> 
+                <val>1030</val> 
+                <val>1040</val> 
+                <val>1050</val>
+                <val>1060</val> 
+                <val>1070</val> 
+                <val>1080</val> 
+                <val>1090</val> 
+                <val>1100</val> 
+                <val>1110</val> 
+                <val>1120</val> 
+                <val>1130</val> 
+                <val>1140</val> 
+                <val>1150</val> 
+            </lifetimes>
+            </DeployInst>
+            </config>
+        </institution>
+
+        <institution>
+        <config>
+        <DemandDrivenDeploymentInst>
+            <calc_method>%s</calc_method>
+            <demand_eq>%s</demand_eq>
+            <facility_commod>
+            <item>
+              <facility>source</facility>
+              <commod>sourceout</commod>
+            </item>
+            <item>
+              <facility>enrichment</facility>
+              <commod>enrichmentout</commod>
+            </item>
+            <item>
+              <facility>fr</facility>
+              <commod>POWER</commod>
+            </item>
+            </facility_commod>
+            <facility_capacity>
+            <item>
+              <facility>source</facility>
+              <capacity>1e9</capacity>
+            </item>    
+            <item>
+              <facility>enrichment</facility>
+              <capacity>1e100</capacity>
+            </item>
+            <item>
+              <facility>fr</facility>
+              <capacity>333.34</capacity>
+            </item>
+            </facility_capacity>
+            <facility_pref>
+            <item>
+              <facility>fr</facility>
+              <pref>t-959</pref>
+            </item>
+            </facility_pref>
+            <buffer_type>
+            <item>
+              <commod>POWER</commod>
+              <type>float</type>
+            </item>
+            </buffer_type>
+            <supply_buffer>
+            <item>
+              <commod>POWER</commod>
+              <buffer>%s</buffer>
+            </item>
+            </supply_buffer>
+        </DemandDrivenDeploymentInst>
+        </config>
+        <name>timeseriesinst</name>
+        </institution>
+
+        <institution>
+        <config>
+        <SupplyDrivenDeploymentInst>
+            <calc_method>%s</calc_method>
+            <facility_commod>
+            <item>
+                <facility>lwrreprocessing</facility>
+                <commod>lwrstorageout</commod>
+            </item>
+            <item>
+                <facility>frreprocessing</facility>
+                <commod>frstorageout</commod>
+            </item>
+            <item>
+                <facility>lwrmixer</facility>
+                <commod>lwrpu</commod>
+            </item>
+            <item>
+                <facility>frmixer</facility>
+                <commod>frpu</commod>
+            </item>
+            <item>
+                <facility>lwrstorage</facility>
+                <commod>lwrout</commod>
+            </item>
+            <item>
+                <facility>frstorage</facility>
+                <commod>frout</commod>
+            </item>
+            <item>
+                <facility>lwrsink</facility>
+                <commod>lwrreprocessingwaste</commod>
+            </item>
+            <item>
+                <facility>frsink</facility>
+                <commod>frreprocessingwaste</commod>
+            </item>
+            </facility_commod>
+            <facility_capacity>
+            <item>
+                <facility>lwrreprocessing</facility>
+                <capacity>1e8</capacity>
+            </item>
+            <item>
+                <facility>frreprocessing</facility>
+                <capacity>1e8</capacity>
+            </item>
+            <item>
+                <facility>lwrmixer</facility>
+                <capacity>1e6</capacity>
+            </item>
+            <item>
+                <facility>frmixer</facility>
+                <capacity>1e6</capacity>
+            </item>
+            <item>
+                <facility>lwrstorage</facility>
+                <capacity>1e7</capacity>
+            </item>
+            <item>
+                <facility>frstorage</facility>
+                <capacity>1e7</capacity>
+            </item>
+            <item>
+                <facility>lwrsink</facility>
+                <capacity>1e10</capacity>
+            </item>
+            <item>
+                <facility>frsink</facility>
+                <capacity>1e10</capacity>
+            </item>
+            </facility_capacity>
+        </SupplyDrivenDeploymentInst>
+        </config>
+        <name>supplydrivendeploymentinst</name>
+        </institution>
+
+        <name>SingleRegion</name>
+    </region>
+    """%(calc_method, demand_eq, buff_size, calc_method)
+
+for calc_method in calc_methods:
+
+    input_file = 'eg01-eg23-flatpower-d3ploy-buffer' + buff_size + '-' + calc_method + '.xml'
+    output_file = 'eg01-eg23-flatpower-d3ploy-buffer' + buff_size + '-' + calc_method + '.sqlite'
+
+    with open(input_file, 'w') as f:
+        f.write('<simulation>\n')
+        f.write(control)
+        f.write(region[calc_method])
+        f.write(recipes)
+        f.write('</simulation>')
+
+    s = subprocess.check_output(['cyclus', '-o', output_file, input_file],
+                            universal_newlines=True, env=ENV)

--- a/input/eg01-eg23/flatpower_d3ploy.py
+++ b/input/eg01-eg23/flatpower_d3ploy.py
@@ -662,7 +662,7 @@ for calc_method in calc_methods:
                 <val>lwr</val>
                 <val>lwr</val>
                 <val>lwr</val>
-            </prototypes> 
+            </prototypes>
             <build_times>
                 <val>1</val>
                 <val>1</val>
@@ -875,7 +875,7 @@ for calc_method in calc_methods:
     input_file = 'eg01-eg23-flatpower-d3ploy-buffer' + buff_size + '-' \
                 + calc_method + '.xml'
     output_file = 'eg01-eg23-flatpower-d3ploy-buffer' + buff_size + '-' \
-                + calc_method + '.sqlite'
+            + calc_method + '.sqlite'
 
     with open(input_file, 'w') as f:
         f.write('<simulation>\n')

--- a/input/eg01-eg23/flatpower_d3ploy_plot.py
+++ b/input/eg01-eg23/flatpower_d3ploy_plot.py
@@ -32,13 +32,13 @@ def plot_several(name, all_dict, commod, calc_methods, demand_eq):
         dict_supply[calc_method] = all_dict[calc_method]['dict_supply']
     
     fig, ax = plt.subplots(figsize=(15, 7))
-    
-    ax.semilogy(*zip(*sorted(dict_demand[calc_method].items())), '-', color='red',
-            label='Demand')
+
+    ax.semilogy(*zip(*sorted(dict_demand[calc_method].items())), '-',
+                color='red', label='Demand')
     
     for calc_method in calc_methods:
         ax.semilogy(*zip(*sorted(dict_supply[calc_method].items())), 'x',
-                label=calc_method + ' Supply', markersize=4) 
+                    label=calc_method + ' Supply', markersize=4)
 
     ax.set_xlabel('Time (month timestep)', fontsize=14)
     if commod.lower() == 'power':
@@ -49,23 +49,25 @@ def plot_several(name, all_dict, commod, calc_methods, demand_eq):
     handles, labels = ax.get_legend_handles_labels()
     ax.legend(handles, labels, fontsize=11, loc='upper center',
               bbox_to_anchor=(1.1, 1.0), fancybox=True)
-   
+
     plt.minorticks_off()
     ax.set_yticks(np.arange(5.8e4, 6.5e4, 2.e3))
     plt.savefig(name, dpi=300, bbox_inches='tight')
     plt.close()
 
+
 direc = os.listdir('./')
 
 # Delete previously generated files
-#hit_list = glob.glob('*.png') + glob.glob('*.csv')
-#for file in hit_list:
-#    os.remove(file)
+# hit_list = glob.glob('*.png') + glob.glob('*.csv')
+# for file in hit_list:
+#     os.remove(file)
 
 ENV = dict(os.environ)
 ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
 
-calc_methods = ["ma", "arma", "arch", "poly", "exp_smoothing", "holt_winters", "fft", "sw_seasonal"]
+calc_methods = ["ma", "arma", "arch", "poly", "exp_smoothing", "holt_winters",
+                "fft", "sw_seasonal"]
 
 demand_eq = "60000"
 
@@ -76,14 +78,15 @@ front_commods = ['sourceout', 'enrichmentout']
 back_commods = ['lwrpu', 'frpu']
 
 add = '-buffer2000'
-#add = sys.argv[1]
+# add = sys.argv[1]
 name = 'eg01-eg23-flatpower-d3ploy' + add
 
 for calc_method in calc_methods:
-    output_file = name + '-' + calc_method +'.sqlite'
+    output_file = name + '-' + calc_method + '.sqlite'
 
-    all_dict['power'] = tester.supply_demand_dict_driving(
-    output_file, demand_eq, 'power')
+    all_dict['power'] = tester.supply_demand_dict_driving(output_file,
+                                                          demand_eq,
+                                                          'power')
 
     metric_dict = tester.metrics(
         all_dict['power'], metric_dict, calc_method, 'power', True)
@@ -106,7 +109,7 @@ for calc_method in calc_methods:
                                                                 commod, False)
         metric_dict = tester.metrics(
             all_dict[commod], metric_dict, calc_method, commod, False)
-  
+
     df = pd.DataFrame(metric_dict)
     df.to_csv(name + '.csv')
 
@@ -115,19 +118,28 @@ calc_methods2 = ["poly", "exp_smoothing", "holt_winters", "fft"]
 calc_methods3 = ["sw_seasonal"]
 
 for calc_method in calc_methods1:
-    output_file = name +'-'+ calc_method +'.sqlite' 
-    all_dict[calc_method] = tester.supply_demand_dict_driving(output_file, demand_eq, 'power')
+    output_file = name + '-' + calc_method + '.sqlite'
+    all_dict[calc_method] = tester.supply_demand_dict_driving(output_file,
+                                                              demand_eq,
+                                                              'power')
 
-plot_several('23-power'+ add +'1', all_dict, 'power', calc_methods1, demand_eq)
+plot_several('23-power' + add + '1', all_dict, 'power', calc_methods1,
+             demand_eq)
 
 for calc_method in calc_methods2:
-    output_file = name +'-'+ calc_method +'.sqlite' 
-    all_dict[calc_method] = tester.supply_demand_dict_driving(output_file, demand_eq, 'power')
+    output_file = name + '-' + calc_method + '.sqlite'
+    all_dict[calc_method] = tester.supply_demand_dict_driving(output_file,
+                                                              demand_eq,
+                                                              'power')
 
-plot_several('23-power'+ add +'2', all_dict, 'power', calc_methods2, demand_eq)
+plot_several('23-power' + add + '2', all_dict, 'power', calc_methods2,
+             demand_eq)
 
 for calc_method in calc_methods3:
-    output_file = name +'-'+ calc_method +'.sqlite' 
-    all_dict[calc_method] = tester.supply_demand_dict_driving(output_file, demand_eq, 'power')
+    output_file = name + '-' + calc_method + '.sqlite'
+    all_dict[calc_method] = tester.supply_demand_dict_driving(output_file,
+                                                              demand_eq,
+                                                              'power')
 
-plot_several('23-power'+ add +'3', all_dict, 'power', calc_methods3, demand_eq)
+plot_several('23-power' + add + '3', all_dict, 'power', calc_methods3,
+             demand_eq)

--- a/input/eg01-eg23/flatpower_d3ploy_plot.py
+++ b/input/eg01-eg23/flatpower_d3ploy_plot.py
@@ -1,0 +1,133 @@
+"""
+This script creates the .csv file and the .png files for power
+asociated to a scenario run with multiple calculations methods.
+
+It produces one .png for NO, one for DO, and one for SO.
+"""
+
+import json
+import re
+import subprocess
+import os
+import sqlite3 as lite
+import copy
+import glob
+import sys
+from matplotlib import pyplot as plt
+import matplotlib
+from matplotlib.ticker import ScalarFormatter, NullFormatter
+import numpy as np
+import pandas as pd
+import d3ploy.tester as tester
+import d3ploy.plotter as plotter
+import collections
+
+
+def plot_several(name, all_dict, commod, calc_methods, demand_eq):
+    dict_demand = {}
+    dict_supply = {}
+
+    for calc_method in calc_methods:
+        dict_demand[calc_method] = all_dict[calc_method]['dict_demand']
+        dict_supply[calc_method] = all_dict[calc_method]['dict_supply']
+    
+    fig, ax = plt.subplots(figsize=(15, 7))
+    
+    ax.semilogy(*zip(*sorted(dict_demand[calc_method].items())), '-', color='red',
+            label='Demand')
+    
+    for calc_method in calc_methods:
+        ax.semilogy(*zip(*sorted(dict_supply[calc_method].items())), 'x',
+                label=calc_method + ' Supply', markersize=4) 
+
+    ax.set_xlabel('Time (month timestep)', fontsize=14)
+    if commod.lower() == 'power':
+        ax.set_ylabel('Power (MW)', fontsize=14)
+    else:
+        ax.set_ylabel('Mass (Kg)', fontsize=14)
+
+    handles, labels = ax.get_legend_handles_labels()
+    ax.legend(handles, labels, fontsize=11, loc='upper center',
+              bbox_to_anchor=(1.1, 1.0), fancybox=True)
+   
+    plt.minorticks_off()
+    ax.set_yticks(np.arange(5.8e4, 6.5e4, 2.e3))
+    plt.savefig(name, dpi=300, bbox_inches='tight')
+    plt.close()
+
+direc = os.listdir('./')
+
+# Delete previously generated files
+#hit_list = glob.glob('*.png') + glob.glob('*.csv')
+#for file in hit_list:
+#    os.remove(file)
+
+ENV = dict(os.environ)
+ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
+
+calc_methods = ["ma", "arma", "arch", "poly", "exp_smoothing", "holt_winters", "fft", "sw_seasonal"]
+
+demand_eq = "60000"
+
+metric_dict = {}
+all_dict = {}
+
+front_commods = ['sourceout', 'enrichmentout']
+back_commods = ['lwrpu', 'frpu']
+
+add = '-buffer2000'
+#add = sys.argv[1]
+name = 'eg01-eg23-flatpower-d3ploy' + add
+
+for calc_method in calc_methods:
+    output_file = name + '-' + calc_method +'.sqlite'
+
+    all_dict['power'] = tester.supply_demand_dict_driving(
+    output_file, demand_eq, 'power')
+
+    metric_dict = tester.metrics(
+        all_dict['power'], metric_dict, calc_method, 'power', True)
+
+    for commod in front_commods:
+        all_dict[commod] = tester.supply_demand_dict_nondriving(output_file,
+                                                                commod, True)
+        metric_dict = tester.metrics(
+            all_dict[commod], metric_dict, calc_method, commod, True)
+
+    commod = 'mixerout'
+    all_dict[commod] = tester.supply_demand_dict_nond3ploy(output_file,
+                                                           commod)
+
+    metric_dict = tester.metrics(
+        all_dict[commod], metric_dict, calc_method, commod, True)
+
+    for commod in back_commods:
+        all_dict[commod] = tester.supply_demand_dict_nondriving(output_file,
+                                                                commod, False)
+        metric_dict = tester.metrics(
+            all_dict[commod], metric_dict, calc_method, commod, False)
+  
+    df = pd.DataFrame(metric_dict)
+    df.to_csv(name + '.csv')
+
+calc_methods1 = ["ma", "arma", "arch"]
+calc_methods2 = ["poly", "exp_smoothing", "holt_winters", "fft"]
+calc_methods3 = ["sw_seasonal"]
+
+for calc_method in calc_methods1:
+    output_file = name +'-'+ calc_method +'.sqlite' 
+    all_dict[calc_method] = tester.supply_demand_dict_driving(output_file, demand_eq, 'power')
+
+plot_several('23-power'+ add +'1', all_dict, 'power', calc_methods1, demand_eq)
+
+for calc_method in calc_methods2:
+    output_file = name +'-'+ calc_method +'.sqlite' 
+    all_dict[calc_method] = tester.supply_demand_dict_driving(output_file, demand_eq, 'power')
+
+plot_several('23-power'+ add +'2', all_dict, 'power', calc_methods2, demand_eq)
+
+for calc_method in calc_methods3:
+    output_file = name +'-'+ calc_method +'.sqlite' 
+    all_dict[calc_method] = tester.supply_demand_dict_driving(output_file, demand_eq, 'power')
+
+plot_several('23-power'+ add +'3', all_dict, 'power', calc_methods3, demand_eq)

--- a/input/eg01-eg23/flatpower_d3ploy_plot.py
+++ b/input/eg01-eg23/flatpower_d3ploy_plot.py
@@ -30,12 +30,12 @@ def plot_several(name, all_dict, commod, calc_methods, demand_eq):
     for calc_method in calc_methods:
         dict_demand[calc_method] = all_dict[calc_method]['dict_demand']
         dict_supply[calc_method] = all_dict[calc_method]['dict_supply']
-    
+
     fig, ax = plt.subplots(figsize=(15, 7))
 
     ax.semilogy(*zip(*sorted(dict_demand[calc_method].items())), '-',
                 color='red', label='Demand')
-    
+
     for calc_method in calc_methods:
         ax.semilogy(*zip(*sorted(dict_supply[calc_method].items())), 'x',
                     label=calc_method + ' Supply', markersize=4)

--- a/input/eg01-eg23/plot_d3ploy.py
+++ b/input/eg01-eg23/plot_d3ploy.py
@@ -23,9 +23,9 @@ import collections
 direc = os.listdir('./')
 
 # Delete previously generated files
-#hit_list = glob.glob('*.png') + glob.glob('*.csv')
-#for file in hit_list:
-#    os.remove(file)
+# hit_list = glob.glob('*.png') + glob.glob('*.csv')
+# for file in hit_list:
+#     os.remove(file)
 
 ENV = dict(os.environ)
 ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
@@ -33,7 +33,7 @@ ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
 # initialize metric dict
 demand_eq = '60000'
 calc_method = 'arch'
-name = "eg01-eg23-flatpower-d3ploy-bufferB2000-"+ calc_method
+name = "eg01-eg23-flatpower-d3ploy-bufferB2000-" + calc_method
 output_file = name + ".sqlite"
 
 # Initialize dicts

--- a/input/eg01-eg23/plot_d3ploy.py
+++ b/input/eg01-eg23/plot_d3ploy.py
@@ -1,0 +1,94 @@
+"""
+This file produces the plots for one scenario.
+The plots are produced for only one calculation method.
+This is not useful to compare different calculation methods
+but to see the outputs of only one simulation.
+"""
+
+import json
+import re
+import subprocess
+import os
+import sqlite3 as lite
+import copy
+import glob
+import sys
+from matplotlib import pyplot as plt
+import numpy as np
+import pandas as pd
+import d3ploy.tester as tester
+import d3ploy.plotter as plotter
+import collections
+
+direc = os.listdir('./')
+
+# Delete previously generated files
+#hit_list = glob.glob('*.png') + glob.glob('*.csv')
+#for file in hit_list:
+#    os.remove(file)
+
+ENV = dict(os.environ)
+ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
+
+# initialize metric dict
+demand_eq = '60000'
+calc_method = 'arch'
+name = "eg01-eg23-flatpower-d3ploy-bufferB2000-"+ calc_method
+output_file = name + ".sqlite"
+
+# Initialize dicts
+metric_dict = {}
+all_dict = {}
+agent_entry_dict = {}
+
+# get agent deployment
+commod_dict = {'enrichmentout': ['enrichment'],
+               'sourceout': ['source'],
+               'power': ['lwr', 'fr'],
+               'lwrstorageout': ['lwrreprocessing'],
+               'frstorageout': ['frreprocessing'],
+               'lwrout': ['lwrstorage'],
+               'frout': ['frstorage'],
+               'lwrpu': ['lwrmixer'],
+               'frpu': ['frmixer'],
+               'lwrreprocessingwaste': ['lwrsink'],
+               'frreprocessingwaste': ['frsink']}
+
+for commod, facility in commod_dict.items():
+    agent_entry_dict[commod] = tester.get_agent_dict(output_file, facility)
+
+all_dict['power'] = tester.supply_demand_dict_driving(
+    output_file, demand_eq, 'power')
+
+plotter.plot_demand_supply_agent(all_dict['power'], agent_entry_dict['power'],
+                                 'power', 'B2000-' + calc_method + '-power',
+                                 True, True, False, 1)
+
+front_commods = ['sourceout', 'enrichmentout']
+back_commods = ['lwrstorageout', 'frstorageout', 'lwrout', 'frout',
+                'lwrreprocessingwaste', 'frreprocessingwaste', 'frpu',
+                'lwrpu']
+
+for commod in front_commods:
+    all_dict[commod] = tester.supply_demand_dict_nondriving(output_file,
+                                                            commod, True)
+    name = 'B2000-' + calc_method + '-' + commod
+    plotter.plot_demand_supply_agent(all_dict[commod],
+                                     agent_entry_dict[commod], commod, name,
+                                     True, True, False, 1)
+    metric_dict = tester.metrics(
+        all_dict[commod], metric_dict, calc_method, commod, True)
+
+for commod in back_commods:
+    all_dict[commod] = tester.supply_demand_dict_nondriving(output_file,
+                                                            commod, False)
+
+    name = 'B2000-' + calc_method + '-' + commod
+    plotter.plot_demand_supply_agent(all_dict[commod],
+                                     agent_entry_dict[commod],
+                                     commod, name, False, True, False, 1)
+    metric_dict = tester.metrics(
+        all_dict[commod], metric_dict, calc_method, commod, False)
+
+df = pd.DataFrame(metric_dict)
+df.to_csv('B2000-' + calc_method + '.csv')

--- a/input/eg01-eg23/plot_diff_buff_sizes.py
+++ b/input/eg01-eg23/plot_diff_buff_sizes.py
@@ -1,0 +1,89 @@
+"""
+This script creates a .png file that compares the cumulative undersupply
+for different calculation methods and different buffer sizes.
+It can also plot for differnet no. of forward/back steps.
+"""
+
+import json
+import re
+import subprocess
+import os
+import sqlite3 as lite
+import copy
+import glob
+import sys
+from matplotlib import pyplot as plt
+import matplotlib
+from matplotlib.ticker import ScalarFormatter, NullFormatter
+import numpy as np
+import pandas as pd
+import d3ploy.tester as tester
+import d3ploy.plotter as plotter
+import collections
+
+def plot_buff(name, calc_methods, buff_sizes, data, buff=True):
+    fig, ax = plt.subplots(figsize=(15, 7))
+    for calc_method in calc_methods:
+        #Plots markers instead of lines.
+        #ax.plot(*zip(*sorted(data[calc_method].items())), 'x',
+        #        label=calc_method, markersize=4)
+        ax.plot(*zip(*sorted(data[calc_method].items())),
+                label=calc_method)
+    if buff:
+        ax.set_xlabel('Buffer Size [MW]', fontsize=14)
+    else: 
+        ax.set_xlabel('Back Steps', fontsize=14)
+    ax.set_ylabel('Cumulative Undersupply [GW]', fontsize=14)
+
+    handles, labels = ax.get_legend_handles_labels()
+    ax.legend(handles, labels, fontsize=11, loc='upper center',
+              bbox_to_anchor=(1.1, 1.0), fancybox=True)
+   
+    plt.savefig(name, dpi=300, bbox_inches='tight')
+    plt.close()
+
+direc = os.listdir('./')
+
+# Delete previously generated files
+#hit_list = glob.glob('*.png') + glob.glob('*.csv')
+#for file in hit_list:
+#    os.remove(file)
+
+ENV = dict(os.environ)
+ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
+
+calc_methods = ["ma", "arma", "arch", "poly", "exp_smoothing", "holt_winters", "fft", "sw_seasonal"]
+
+demand_eq = "60000"
+
+metric_dict = {}
+all_dict = {}
+cumulative_under = {}
+timesteps_under = {}
+
+name = 'eg01-eg23-flatpower-d3ploy-buffer'
+
+#add_list contains the buffer sizes
+#it can be replaced by forward steps/back steps.
+add_list = ['0', '2000', '4000']
+#add_list = ['1', '3', '5']
+
+for calc_method in calc_methods:
+
+    cumulative_under[calc_method] = {}
+    timesteps_under[calc_method] = {}
+
+    for add in add_list:
+        output_file = name + add + '-' + calc_method +'.sqlite'
+        
+        all_dict['power'] = tester.supply_demand_dict_driving(
+            output_file, demand_eq, 'power')
+        metric_dict = tester.metrics(
+            all_dict['power'], metric_dict, calc_method, 'power', True)
+
+        cumulative_under[calc_method][add] = metric_dict['power_residuals_under'][calc_method] - 60e3
+        timesteps_under[calc_method][add] = metric_dict['power_undersupply'][calc_method] - 1
+
+plot_buff('asave/23-buff', calc_methods, add_list, cumulative_under)
+#plot_buff('asave/23-for', calc_methods, add_list, cumulative_under,
+#          buff = False)

--- a/input/eg01-eg23/plot_diff_buff_sizes.py
+++ b/input/eg01-eg23/plot_diff_buff_sizes.py
@@ -85,8 +85,10 @@ for calc_method in calc_methods:
         metric_dict = tester.metrics(all_dict['power'], metric_dict,
                                      calc_method, 'power', True)
 
-        cumulative_under[calc_method][add] = metric_dict['power_residuals_under'][calc_method] - 60e3
-        timesteps_under[calc_method][add] = metric_dict['power_undersupply'][calc_method] - 1
+        cumulative_under[calc_method][add] = \
+            metric_dict['power_residuals_under'][calc_method] - 60e3
+        timesteps_under[calc_method][add] = \
+            metric_dict['power_undersupply'][calc_method] - 1
 
 plot_buff('asave/23-buff', calc_methods, add_list, cumulative_under)
 # plot_buff('asave/23-for', calc_methods, add_list, cumulative_under,

--- a/input/eg01-eg23/plot_diff_buff_sizes.py
+++ b/input/eg01-eg23/plot_diff_buff_sizes.py
@@ -21,38 +21,41 @@ import d3ploy.tester as tester
 import d3ploy.plotter as plotter
 import collections
 
+
 def plot_buff(name, calc_methods, buff_sizes, data, buff=True):
     fig, ax = plt.subplots(figsize=(15, 7))
     for calc_method in calc_methods:
-        #Plots markers instead of lines.
-        #ax.plot(*zip(*sorted(data[calc_method].items())), 'x',
-        #        label=calc_method, markersize=4)
+        # Plots markers instead of lines.
+        # ax.plot(*zip(*sorted(data[calc_method].items())), 'x',
+        #         label=calc_method, markersize=4)
         ax.plot(*zip(*sorted(data[calc_method].items())),
                 label=calc_method)
     if buff:
         ax.set_xlabel('Buffer Size [MW]', fontsize=14)
-    else: 
+    else:
         ax.set_xlabel('Back Steps', fontsize=14)
     ax.set_ylabel('Cumulative Undersupply [GW]', fontsize=14)
 
     handles, labels = ax.get_legend_handles_labels()
     ax.legend(handles, labels, fontsize=11, loc='upper center',
               bbox_to_anchor=(1.1, 1.0), fancybox=True)
-   
+
     plt.savefig(name, dpi=300, bbox_inches='tight')
     plt.close()
+
 
 direc = os.listdir('./')
 
 # Delete previously generated files
-#hit_list = glob.glob('*.png') + glob.glob('*.csv')
-#for file in hit_list:
-#    os.remove(file)
+# hit_list = glob.glob('*.png') + glob.glob('*.csv')
+# for file in hit_list:
+#     os.remove(file)
 
 ENV = dict(os.environ)
 ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
 
-calc_methods = ["ma", "arma", "arch", "poly", "exp_smoothing", "holt_winters", "fft", "sw_seasonal"]
+calc_methods = ["ma", "arma", "arch", "poly", "exp_smoothing", "holt_winters",
+                "fft", "sw_seasonal"]
 
 demand_eq = "60000"
 
@@ -63,10 +66,10 @@ timesteps_under = {}
 
 name = 'eg01-eg23-flatpower-d3ploy-buffer'
 
-#add_list contains the buffer sizes
-#it can be replaced by forward steps/back steps.
+# add_list contains the buffer sizes
+# it can be replaced by forward steps/back steps.
 add_list = ['0', '2000', '4000']
-#add_list = ['1', '3', '5']
+# add_list = ['1', '3', '5']
 
 for calc_method in calc_methods:
 
@@ -74,16 +77,17 @@ for calc_method in calc_methods:
     timesteps_under[calc_method] = {}
 
     for add in add_list:
-        output_file = name + add + '-' + calc_method +'.sqlite'
-        
-        all_dict['power'] = tester.supply_demand_dict_driving(
-            output_file, demand_eq, 'power')
-        metric_dict = tester.metrics(
-            all_dict['power'], metric_dict, calc_method, 'power', True)
+        output_file = name + add + '-' + calc_method + '.sqlite'
+
+        all_dict['power'] = tester.supply_demand_dict_driving(output_file,
+                                                              demand_eq,
+                                                              'power')
+        metric_dict = tester.metrics(all_dict['power'], metric_dict,
+                                     calc_method, 'power', True)
 
         cumulative_under[calc_method][add] = metric_dict['power_residuals_under'][calc_method] - 60e3
         timesteps_under[calc_method][add] = metric_dict['power_undersupply'][calc_method] - 1
 
 plot_buff('asave/23-buff', calc_methods, add_list, cumulative_under)
-#plot_buff('asave/23-for', calc_methods, add_list, cumulative_under,
-#          buff = False)
+# plot_buff('asave/23-for', calc_methods, add_list, cumulative_under,
+#           buff = False)

--- a/input/eg01-eg23/plot_flatpower_nond3ploy.py
+++ b/input/eg01-eg23/plot_flatpower_nond3ploy.py
@@ -18,9 +18,9 @@ import collections
 direc = os.listdir('./')
 
 # Delete previously generated files
-#hit_list = glob.glob('*.png') + glob.glob('*.csv') + glob.glob('*.txt')
-#for file in hit_list:
-#    os.remove(file)
+# hit_list = glob.glob('*.png') + glob.glob('*.csv') + glob.glob('*.txt')
+# for file in hit_list:
+#     os.remove(file)
 
 ENV = dict(os.environ)
 ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')

--- a/input/eg01-eg23/plot_flatpower_nond3ploy.py
+++ b/input/eg01-eg23/plot_flatpower_nond3ploy.py
@@ -1,0 +1,84 @@
+# this file produces the plots for the case eg01-eg23-flatpower-d3ploy.xml
+
+import json
+import re
+import subprocess
+import os
+import sqlite3 as lite
+import copy
+import glob
+import sys
+from matplotlib import pyplot as plt
+import numpy as np
+import pandas as pd
+import d3ploy.tester as tester
+import d3ploy.plotter as plotter
+import collections
+
+direc = os.listdir('./')
+
+# Delete previously generated files
+#hit_list = glob.glob('*.png') + glob.glob('*.csv') + glob.glob('*.txt')
+#for file in hit_list:
+#    os.remove(file)
+
+ENV = dict(os.environ)
+ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
+
+# initialize metric dict
+demand_eq = '60000'
+calc_method = 'ma'
+name = "eg01-eg23-flatpower-nond3ploy"
+output_file = name + ".sqlite"
+
+# Initialize dicts
+metric_dict = {}
+all_dict = {}
+agent_entry_dict = {}
+
+# get agent deployment
+commod_dict = {'enrichmentout': ['enrichment'],
+               'sourceout': ['source'],
+               'power': ['lwr', 'fr'],
+               'lwrstorageout': ['lwrreprocessing'],
+               'frstorageout': ['frreprocessing'],
+               'lwrout': ['lwrstorage'],
+               'frout': ['frstorage'],
+               'lwrpu': ['pumixerlwr'],
+               'frpu': ['pumixerfr'],
+               'lwrreprocessingwaste': ['lwrsink'],
+               'frreprocessingwaste': ['frsink']}
+
+for commod, facility in commod_dict.items():
+    agent_entry_dict[commod] = tester.get_agent_dict(output_file, facility)
+
+# get supply deamnd dict
+all_dict['power'] = tester.supply_demand_dict_nond3ploy(
+    output_file, 'power', demand_eq)
+
+plotter.plot_demand_supply_nond3ploy(all_dict['power'],
+                                     agent_entry_dict['power'], 'power',
+                                     'eg01-eg23-flatpower-nond3ploy_power',
+                                     True, True, 1)
+
+front_commods = ['sourceout', 'enrichmentout']
+back_commods = ['lwrstorageout', 'frstorageout', 'lwrout', 'frout',
+                'lwrreprocessingwaste', 'frreprocessingwaste', 'frpu',
+                'lwrpu']
+
+for commod in front_commods:
+    all_dict[commod] = tester.supply_demand_dict_nond3ploy(output_file,
+                                                           commod)
+    name = 'eg01-eg23-flatpower-nond3ploy_' + commod
+    plotter.plot_demand_supply_nond3ploy(all_dict[commod],
+                                         agent_entry_dict[commod], commod,
+                                         name, True, True, 1)
+
+for commod in back_commods:
+    all_dict[commod] = tester.supply_demand_dict_nond3ploy(output_file,
+                                                           commod, False)
+
+    name = 'eg01-eg23-flatpower-nond3ploy_' + commod
+    plotter.plot_demand_supply_nond3ploy(all_dict[commod],
+                                         agent_entry_dict[commod],
+                                         commod, name, False, True, 1)

--- a/input/eg01-eg24/flatpower_d3ploy.py
+++ b/input/eg01-eg24/flatpower_d3ploy.py
@@ -27,7 +27,8 @@ direc = os.listdir('./')
 ENV = dict(os.environ)
 ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
 
-calc_methods = ["ma", "arma", "arch", "poly", "exp_smoothing", "holt_winters", "fft", "sw_seasonal"]
+calc_methods = ["ma", "arma", "arch", "poly", "exp_smoothing", "holt_winters",
+                "fft", "sw_seasonal"]
 
 demand_eq = "60000"
 buff_size = "2000"

--- a/input/eg01-eg24/flatpower_d3ploy.py
+++ b/input/eg01-eg24/flatpower_d3ploy.py
@@ -412,7 +412,7 @@ control = """
                         <item>
                             <commodity>fru</commodity>
                             <pref>1.0</pref>
-                        </item>                    
+                        </item>
                     </commodities>
                 </stream>
                 <stream>
@@ -532,7 +532,7 @@ recipes = """
     <nuclide> <id>Cs135</id>  <comp>0.0006596706</comp> </nuclide>
     <nuclide> <id>Cs137</id>  <comp>0.0018169192</comp> </nuclide>
     <nuclide> <id>H1</id>  <comp>0.0477938151</comp> </nuclide>
-</recipe> 
+</recipe>
 
 <recipe>
     <name>frinrecipe</name>
@@ -647,7 +647,7 @@ for calc_method in calc_methods:
             </NullRegion>
         </config>
 
-        <institution> 
+        <institution>
             <name>lwr_inst</name>
             <config>
             <DeployInst>
@@ -716,7 +716,7 @@ for calc_method in calc_methods:
                 <val>3</val>
                 <val>3</val>
                 <val>3</val>
-            </n_build> 
+            </n_build>
             <lifetimes>
                 <val>960</val>
                 <val>970</val>
@@ -885,7 +885,7 @@ for calc_method in calc_methods:
     input_file = 'eg01-eg24-flatpower-d3ploy-buffer' + buff_size + '-' \
                 + calc_method + '.xml'
     output_file = 'eg01-eg24-flatpower-d3ploy-buffer' + buff_size + '-' \
-                 + calc_method + '.sqlite'
+        + calc_method + '.sqlite'
 
     with open(input_file, 'w') as f:
         f.write('<simulation>\n')

--- a/input/eg01-eg24/flatpower_d3ploy.py
+++ b/input/eg01-eg24/flatpower_d3ploy.py
@@ -785,7 +785,7 @@ for calc_method in calc_methods:
             <buffer_type>
             <item>
               <commod>POWER</commod>
-              <type>float</type>
+              <type>abs</type>
             </item>
             </buffer_type>
             <supply_buffer>

--- a/input/eg01-eg24/flatpower_d3ploy.py
+++ b/input/eg01-eg24/flatpower_d3ploy.py
@@ -1,0 +1,896 @@
+"""
+Running this script generates .xml files and runs them producing the .sqlite
+files for all the prediction methods.
+
+The user can choose a demand equation (demand_eq) and a buffer size
+(buff_size). The buffer plays its role one time step before the transition
+starts. The transition starts at after 960 time steps (80 years).
+"""
+
+import json
+import re
+import subprocess
+import os
+import sqlite3 as lite
+import copy
+import glob
+import sys
+from matplotlib import pyplot as plt
+import numpy as np
+import pandas as pd
+import d3ploy.tester as tester
+import d3ploy.plotter as plotter
+import collections
+
+direc = os.listdir('./')
+
+ENV = dict(os.environ)
+ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
+
+calc_methods = ["ma", "arma", "arch", "poly", "exp_smoothing", "holt_winters", "fft", "sw_seasonal"]
+
+demand_eq = "60000"
+buff_size = "2000"
+
+control = """
+<control>
+    <duration>1440</duration>
+    <startmonth>1</startmonth>
+    <startyear>2000</startyear>
+    <decay>lazy</decay>
+</control>
+
+<archetypes>
+        <spec>
+            <lib>cycamore</lib>
+            <name>Source</name>
+        </spec>
+        <spec>
+            <lib>cycamore</lib>
+            <name>Enrichment</name>
+        </spec>
+        <spec>
+            <lib>cycamore</lib>
+            <name>Reactor</name>
+        </spec>
+        <spec>
+            <lib>cycamore</lib>
+            <name>Storage</name>
+        </spec>
+        <spec>
+            <lib>cycamore</lib>
+            <name>Separations</name>
+        </spec>
+        <spec>
+            <lib>cycamore</lib>
+            <name>Mixer</name>
+        </spec>
+        <spec>
+            <lib>cycamore</lib>
+            <name>Sink</name>
+        </spec>
+        <spec>
+            <lib>agents</lib>
+            <name>NullRegion</name>
+        </spec>
+        <spec>
+            <lib>agents</lib>
+            <name>NullInst</name>
+        </spec>
+        <spec>
+            <lib>cycamore</lib>
+            <name>DeployInst</name>
+        </spec>
+        <spec>
+            <lib>d3ploy.demand_driven_deployment_inst</lib>
+            <name>DemandDrivenDeploymentInst</name>
+        </spec>
+        <spec>
+            <lib>d3ploy.supply_driven_deployment_inst</lib>
+            <name>SupplyDrivenDeploymentInst</name>
+        </spec>
+</archetypes>
+
+<facility>
+    <name>source</name>
+    <config>
+        <Source>
+            <outcommod>sourceout</outcommod>
+            <outrecipe>sourceoutrecipe</outrecipe>
+            <throughput>1e9</throughput>
+        </Source>
+    </config>
+</facility>
+
+<facility>
+    <name>enrichment</name>
+    <config>
+        <Enrichment>
+            <feed_commod>sourceout</feed_commod>
+            <feed_recipe>sourceoutrecipe</feed_recipe>
+            <product_commod>enrichmentout</product_commod>
+            <tails_assay>0.0025</tails_assay>
+            <tails_commod>enrichmentwaste</tails_commod>
+            <swu_capacity>1e100</swu_capacity>
+            <initial_feed>5e7</initial_feed>
+            <max_feed_inventory>1e8</max_feed_inventory>
+        </Enrichment>
+    </config>
+</facility>
+
+<facility>
+    <name>lwr</name>
+    <config>
+        <Reactor>
+            <fuel_inrecipes>
+                <val>lwrinrecipe</val>
+            </fuel_inrecipes>
+            <fuel_outrecipes>
+                <val>lwroutrecipe</val>
+            </fuel_outrecipes>
+            <fuel_incommods>
+                <val>enrichmentout</val>
+            </fuel_incommods>
+            <fuel_outcommods>
+                <val>lwrout</val>
+            </fuel_outcommods>
+            <cycle_time>18</cycle_time>
+            <refuel_time>0</refuel_time>
+            <assem_size>29863.3</assem_size>
+            <n_assem_core>3</n_assem_core>
+            <n_assem_batch>1</n_assem_batch>
+            <power_cap>1000</power_cap>
+        </Reactor>
+    </config>
+</facility>
+
+<facility>
+    <name>lwr2</name>
+    <lifetime>960</lifetime>
+    <config>
+        <Reactor>
+            <fuel_inrecipes>
+                <val>lwrinrecipe</val>
+            </fuel_inrecipes>
+            <fuel_outrecipes>
+                <val>lwroutrecipe</val>
+            </fuel_outrecipes>
+            <fuel_incommods>
+                <val>enrichmentout</val>
+            </fuel_incommods>
+            <fuel_outcommods>
+                <val>lwrout</val>
+            </fuel_outcommods>
+            <cycle_time>18</cycle_time>
+            <refuel_time>0</refuel_time>
+            <assem_size>29863.3</assem_size>
+            <n_assem_core>3</n_assem_core>
+            <n_assem_batch>1</n_assem_batch>
+            <power_cap>1000</power_cap>
+        </Reactor>
+    </config>
+</facility>
+
+<facility>
+    <name>fr</name>
+    <lifetime>720</lifetime>
+    <config>
+        <Reactor>
+            <fuel_inrecipes>
+                <val>frinrecipe</val>
+            </fuel_inrecipes>
+            <fuel_outrecipes>
+                <val>froutrecipe</val>
+            </fuel_outrecipes>
+            <fuel_incommods>
+                <val>mixerout</val>
+            </fuel_incommods>
+            <fuel_outcommods>
+                <val>frout</val>
+            </fuel_outcommods>
+            <cycle_time>12</cycle_time>
+            <refuel_time>0</refuel_time>
+            <assem_size>5867</assem_size>
+            <n_assem_core>4</n_assem_core>
+            <n_assem_batch>1</n_assem_batch>
+            <power_cap>333.34</power_cap>
+        </Reactor>
+    </config>
+</facility>
+
+<facility>
+    <name>lwrstorage</name>
+    <config>
+        <Storage>
+            <in_commods>
+                <val>lwrout</val>
+            </in_commods>
+            <residence_time>36</residence_time>
+            <out_commods>
+                <val>lwrstorageout</val>
+            </out_commods>
+            <max_inv_size>1e7</max_inv_size>
+        </Storage>
+    </config>
+</facility>
+
+<facility>
+    <name>frstorage</name>
+    <config>
+        <Storage>
+            <in_commods>
+                <val>frout</val>
+            </in_commods>
+            <residence_time>36</residence_time>
+            <out_commods>
+                <val>frstorageout</val>
+            </out_commods>
+            <max_inv_size>1e7</max_inv_size>
+        </Storage>
+    </config>
+</facility>
+
+<facility>
+    <name>lwrreprocessing</name>
+    <config>
+        <Separations>
+            <feed_commods>
+                <val>lwrstorageout</val>
+            </feed_commods>
+            <feedbuf_size>1e8</feedbuf_size>
+            <throughput>1e8</throughput>
+            <leftover_commod>lwrreprocessingwaste</leftover_commod>
+            <leftoverbuf_size>1e8</leftoverbuf_size>
+            <streams>
+                <item>
+                    <commod>lwrtru</commod>
+                    <info>
+                        <buf_size>1e8</buf_size>
+                        <efficiencies>
+                              <item>
+                                <comp>Np</comp>
+                                <eff>1.0</eff>
+                              </item>
+                              <item>
+                                <comp>Am</comp>
+                                <eff>1.0</eff>
+                              </item>
+                              <item>
+                                <comp>Cm</comp>
+                                <eff>1.0</eff>
+                              </item>
+                              <item>
+                                <comp>Pu</comp>
+                                <eff>1.0</eff>
+                              </item>
+                        </efficiencies>
+                    </info>
+                </item>
+                <item>
+                    <commod>lwru</commod>
+                    <info>
+                        <buf_size>1e8</buf_size>
+                        <efficiencies>
+                            <item>
+                                <comp>U</comp>
+                                <eff>1.0</eff>
+                            </item>
+                        </efficiencies>
+                    </info>
+                </item>
+            </streams>
+        </Separations>
+    </config>
+</facility>
+
+<facility>
+    <name>frreprocessing</name>
+    <config>
+        <Separations>
+            <feed_commods>
+                <val>frstorageout</val>
+            </feed_commods>
+            <feedbuf_size>1e8</feedbuf_size>
+            <throughput>1e8</throughput>
+            <leftover_commod>frreprocessingwaste</leftover_commod>
+            <leftoverbuf_size>1e8</leftoverbuf_size>
+            <streams>
+                <item>
+                    <commod>frtru</commod>
+                    <info>
+                        <buf_size>1e8</buf_size>
+                        <efficiencies>
+                            <item>
+                                <comp>Np</comp>
+                                <eff>1.0</eff>
+                            </item>
+                            <item>
+                                <comp>Am</comp>
+                                <eff>1.0</eff>
+                            </item>
+                            <item>
+                                <comp>Cm</comp>
+                                <eff>1.0</eff>
+                            </item>
+                            <item>
+                                <comp>Pu</comp>
+                                <eff>1.0</eff>
+                            </item>
+                        </efficiencies>
+                    </info>
+                </item>
+                <item>
+                    <commod>fru</commod>
+                    <info>
+                        <buf_size>1e8</buf_size>
+                        <efficiencies>
+                            <item>
+                                <comp>U</comp>
+                                <eff>1.0</eff>
+                            </item>
+                        </efficiencies>
+                    </info>
+                </item>
+            </streams>
+        </Separations>
+    </config>
+</facility>
+
+<facility>
+    <name>lwrmixer</name>
+    <config>
+        <Mixer>
+            <in_streams>
+                <stream>
+                    <info>
+                        <mixing_ratio>0.139</mixing_ratio>
+                        <buf_size>1e6</buf_size>
+                    </info>
+                    <commodities>
+                        <item>
+                            <commodity>lwrtru</commodity>
+                            <pref>1.0</pref>
+                        </item>          
+                    </commodities>
+                </stream>
+                <stream>
+                    <info>
+                        <mixing_ratio>0.771</mixing_ratio>
+                        <buf_size>1e7</buf_size>
+                    </info>
+                    <commodities>
+                        <item>
+                            <commodity>lwru</commodity>
+                            <pref>1.0</pref>
+                        </item>                    
+                    </commodities>
+                </stream>
+                <stream>
+                    <info>
+                        <mixing_ratio>0.09</mixing_ratio>
+                        <buf_size>1e7</buf_size>
+                    </info>
+                    <commodities>
+                        <item>
+                            <commodity>sourceout</commodity>
+                            <pref>1.0</pref>
+                        </item>
+                    </commodities>
+                </stream>
+            </in_streams>
+            <out_commod>mixerout</out_commod>
+            <out_buf_size>1e10</out_buf_size>
+            <throughput>1e7</throughput>
+        </Mixer>
+    </config>
+</facility>
+
+<facility>
+    <name>frmixer</name>
+    <config>
+        <Mixer>
+            <in_streams>
+                <stream>
+                    <info>
+                        <mixing_ratio>0.139</mixing_ratio>
+                        <buf_size>1e6</buf_size>
+                    </info>
+                    <commodities>
+                        <item>
+                            <commodity>frtru</commodity>
+                            <pref>1.0</pref>
+                        </item>          
+                    </commodities>
+                </stream>
+                <stream>
+                    <info>
+                        <mixing_ratio>0.771</mixing_ratio>
+                        <buf_size>1e7</buf_size>
+                    </info>
+                    <commodities>
+                        <item>
+                            <commodity>fru</commodity>
+                            <pref>1.0</pref>
+                        </item>                    
+                    </commodities>
+                </stream>
+                <stream>
+                    <info>
+                        <mixing_ratio>0.09</mixing_ratio>
+                        <buf_size>1e7</buf_size>
+                    </info>
+                    <commodities>
+                        <item>
+                            <commodity>sourceout</commodity>
+                            <pref>1.0</pref>
+                        </item>
+                    </commodities>
+                </stream>
+            </in_streams>
+            <out_commod>mixerout</out_commod>
+            <out_buf_size>1e10</out_buf_size>
+            <throughput>1e7</throughput>
+        </Mixer>
+    </config>
+</facility>
+
+<facility>
+    <name>lwrsink</name>
+    <config>
+        <Sink>
+            <in_commods>
+                <val>lwrreprocessingwaste</val>
+            </in_commods>
+            <max_inv_size>1e20</max_inv_size>
+        </Sink>
+    </config>
+</facility>
+
+<facility>
+    <name>frsink</name>
+    <config>
+        <Sink>
+            <in_commods>
+                <val>frreprocessingwaste</val>
+            </in_commods>
+            <max_inv_size>1e20</max_inv_size>
+        </Sink>
+    </config>
+</facility>
+"""
+
+recipes = """
+<recipe>
+    <name>sourceoutrecipe</name>
+    <basis>mass</basis>
+    <nuclide> <id>U235</id> <comp>0.711</comp> </nuclide>
+    <nuclide> <id>U238</id> <comp>99.289</comp> </nuclide>
+</recipe>
+ 
+<recipe>
+    <name>lwrinrecipe</name>
+    <basis>mass</basis>
+    <nuclide> <id>U234</id>  <comp>0.0002558883</comp> </nuclide> 
+    <nuclide> <id>U235</id>  <comp>0.0319885317</comp> </nuclide> 
+    <nuclide> <id>U238</id>  <comp>0.96775558</comp> </nuclide> 
+</recipe> 
+
+<recipe>
+    <name>lwroutrecipe</name>
+    <basis>mass</basis>
+    <nuclide> <id>He4</id>  <comp>9.47457840128509E-07</comp> </nuclide> 
+    <nuclide> <id>Ra226</id>  <comp>9.78856442957042E-14</comp> </nuclide> 
+    <nuclide> <id>Ra228</id>  <comp>2.75087759176098E-20</comp> </nuclide> 
+    <nuclide> <id>Pb206</id>  <comp>5.57475193532078E-18</comp> </nuclide> 
+    <nuclide> <id>Pb207</id>  <comp>1.68592497990149E-15</comp> </nuclide> 
+    <nuclide> <id>Pb208</id>  <comp>3.6888358546006E-12</comp> </nuclide> 
+    <nuclide> <id>Pb210</id>  <comp>3.02386544437848E-19</comp> </nuclide> 
+    <nuclide> <id>Th228</id>  <comp>8.47562285269577E-12</comp> </nuclide> 
+    <nuclide> <id>Th229</id>  <comp>2.72787861516683E-12</comp> </nuclide> 
+    <nuclide> <id>Th230</id>  <comp>2.6258831537493E-09</comp> </nuclide> 
+    <nuclide> <id>Th232</id>  <comp>4.17481422959E-10</comp> </nuclide> 
+    <nuclide> <id>Bi209</id>  <comp>6.60770597104927E-16</comp> </nuclide> 
+    <nuclide> <id>Ac227</id>  <comp>3.0968621961773E-14</comp> </nuclide> 
+    <nuclide> <id>Pa231</id>  <comp>9.24658854635179E-10</comp> </nuclide> 
+    <nuclide> <id>U232</id>  <comp>0.000000001</comp> </nuclide> 
+    <nuclide> <id>U233</id>  <comp>2.21390148606282E-09</comp> </nuclide> 
+    <nuclide> <id>U234</id>  <comp>0.0001718924</comp> </nuclide> 
+    <nuclide> <id>U235</id>  <comp>0.0076486597</comp> </nuclide> 
+    <nuclide> <id>U236</id>  <comp>0.0057057461</comp> </nuclide> 
+    <nuclide> <id>U238</id>  <comp>0.9208590237</comp> </nuclide> 
+    <nuclide> <id>Np237</id>  <comp>0.0006091729</comp> </nuclide> 
+    <nuclide> <id>Pu238</id>  <comp>0.000291487</comp> </nuclide> 
+    <nuclide> <id>Pu239</id>  <comp>0.0060657301</comp> </nuclide> 
+    <nuclide> <id>Pu240</id>  <comp>0.0029058707</comp> </nuclide> 
+    <nuclide> <id>Pu241</id>  <comp>0.0017579218</comp> </nuclide> 
+    <nuclide> <id>Pu242</id>  <comp>0.0008638616</comp> </nuclide> 
+    <nuclide> <id>Pu244</id>  <comp>2.86487251922763E-08</comp> </nuclide> 
+    <nuclide> <id>Am241</id>  <comp>6.44271331287386E-05</comp> </nuclide> 
+    <nuclide> <id>Am242m</id>  <comp>8.53362027193319E-07</comp> </nuclide> 
+    <nuclide> <id>Am243</id>  <comp>0.0001983912</comp> </nuclide> 
+    <nuclide> <id>Cm242</id>  <comp>2.58988475560194E-05</comp> </nuclide> 
+    <nuclide> <id>Cm243</id>  <comp>0.000000771</comp> </nuclide> 
+    <nuclide> <id>Cm244</id>  <comp>8.5616190260478E-05</comp> </nuclide> 
+    <nuclide> <id>Cm245</id>  <comp>5.72174539442251E-06</comp> </nuclide> 
+    <nuclide> <id>Cm246</id>  <comp>7.29567535786554E-07</comp> </nuclide> 
+    <nuclide> <id>Cm247</id>  <comp>0.00000001</comp> </nuclide> 
+    <nuclide> <id>Cm248</id>  <comp>7.69165773748653E-10</comp> </nuclide> 
+    <nuclide> <id>Cm250</id>  <comp>4.2808095130239E-18</comp> </nuclide> 
+    <nuclide> <id>Cf249</id>  <comp>1.64992658175413E-12</comp> </nuclide> 
+    <nuclide> <id>Cf250</id>  <comp>2.04190913935875E-12</comp> </nuclide> 
+    <nuclide> <id>Cf251</id>  <comp>9.86556100338561E-13</comp> </nuclide> 
+    <nuclide> <id>Cf252</id>  <comp>6.57970721693466E-13</comp> </nuclide> 
+    <nuclide> <id>H3</id>  <comp>8.58461800264195E-08</comp> </nuclide> 
+    <nuclide> <id>C14</id>  <comp>4.05781943561107E-11</comp> </nuclide> 
+    <nuclide> <id>Kr81</id>  <comp>4.21681236076192E-11</comp> </nuclide> 
+    <nuclide> <id>Kr85</id>  <comp>3.44484671160181E-05</comp> </nuclide> 
+    <nuclide> <id>Sr90</id>  <comp>0.0007880649</comp> </nuclide> 
+    <nuclide> <id>Tc99</id>  <comp>0.0011409492</comp> </nuclide> 
+    <nuclide> <id>I129</id>  <comp>0.0002731878</comp> </nuclide> 
+    <nuclide> <id>Cs134</id>  <comp>0.0002300898</comp> </nuclide> 
+    <nuclide> <id>Cs135</id>  <comp>0.0006596706</comp> </nuclide> 
+    <nuclide> <id>Cs137</id>  <comp>0.0018169192</comp> </nuclide> 
+    <nuclide> <id>H1</id>  <comp>0.0477938151</comp> </nuclide> 
+</recipe> 
+
+<recipe>
+    <name>frinrecipe</name>
+    <basis>mass</basis>
+    <nuclide> <id>He4</id>  <comp>8.12E-11</comp> </nuclide> 
+    <nuclide> <id>U232</id>  <comp>4.71E-09</comp> </nuclide> 
+    <nuclide> <id>U234</id>  <comp>0.0003</comp> </nuclide> 
+    <nuclide> <id>U235</id>  <comp>0.0004</comp> </nuclide> 
+    <nuclide> <id>U236</id>  <comp>0.0003</comp> </nuclide> 
+    <nuclide> <id>U238</id>  <comp>0.83</comp> </nuclide> 
+    <nuclide> <id>Np237</id>  <comp>0.0007</comp> </nuclide> 
+    <nuclide> <id>Pu238</id>  <comp>0.0022</comp> </nuclide> 
+    <nuclide> <id>Pu239</id>  <comp>0.0947</comp> </nuclide> 
+    <nuclide> <id>Pu240</id>  <comp>0.0518</comp> </nuclide> 
+    <nuclide> <id>Pu241</id>  <comp>0.0072</comp> </nuclide> 
+    <nuclide> <id>Pu242</id>  <comp>0.0057</comp> </nuclide> 
+    <nuclide> <id>Am241</id>  <comp>0.0031</comp> </nuclide> 
+    <nuclide> <id>Am242m</id>  <comp>0.0002</comp> </nuclide> 
+    <nuclide> <id>Am243</id>  <comp>0.0016</comp> </nuclide> 
+    <nuclide> <id>Cm242</id>  <comp>0.0000</comp> </nuclide> 
+    <nuclide> <id>Cm243</id>  <comp>0.0000</comp> </nuclide> 
+    <nuclide> <id>Cm244</id>  <comp>0.0011</comp> </nuclide> 
+    <nuclide> <id>Cm245</id>  <comp>0.0003</comp> </nuclide> 
+    <nuclide> <id>Cm246</id>  <comp>0.0001</comp> </nuclide> 
+</recipe>
+
+<recipe>
+    <name>froutrecipe</name>
+    <basis>mass</basis>
+    <nuclide> <id>H1</id>  <comp>2.2488058046007715e-06</comp> </nuclide> 
+    <nuclide> <id>H2</id>  <comp>6.889405066117969e-07</comp> </nuclide> 
+    <nuclide> <id>H3</id>  <comp>9.22920301310143e-06</comp> </nuclide> 
+    <nuclide> <id>He3</id>  <comp>9.22920301310143e-06</comp> </nuclide> 
+    <nuclide> <id>He4</id>  <comp>0.00014233770844149392</comp> </nuclide> 
+    <nuclide> <id>Br85</id>  <comp>0.0004010153703579988</comp> </nuclide> 
+    <nuclide> <id>Kr82</id>  <comp>3.5746913078914e-07</comp> </nuclide> 
+    <nuclide> <id>Kr85</id>  <comp>8.969225463436604e-05</comp> </nuclide> 
+    <nuclide> <id>Kr85m</id>  <comp>0.0004010153703579988</comp> </nuclide> 
+    <nuclide> <id>Sr90</id>  <comp>0.0013200360084231696</comp> </nuclide> 
+    <nuclide> <id>Zr95</id>  <comp>0.003043037218826824</comp> </nuclide> 
+    <nuclide> <id>Nb94</id>  <comp>1.6573568791132852e-09</comp> </nuclide> 
+    <nuclide> <id>Nb95</id>  <comp>0.0030417373310784998</comp> </nuclide> 
+    <nuclide> <id>Nb95m</id>  <comp>3.288716003260088e-05</comp> </nuclide> 
+    <nuclide> <id>Mo94</id>  <comp>3.1197305959779486e-12</comp> </nuclide> 
+    <nuclide> <id>Mo96</id>  <comp>1.1049045860755233e-06</comp> </nuclide> 
+    <nuclide> <id>Mo99</id>  <comp>0.0037826733476232634</comp> </nuclide> 
+    <nuclide> <id>Tc99</id>  <comp>0.0037826733476232634</comp> </nuclide> 
+    <nuclide> <id>Ru103</id>  <comp>0.004283130130728059</comp> </nuclide> 
+    <nuclide> <id>Ru106</id>  <comp>0.00268426820028936</comp> </nuclide> 
+    <nuclide> <id>Rh106</id>  <comp>0.00268426820028936</comp> </nuclide> 
+    <nuclide> <id>Sn121m</id>  <comp>3.444702533058985e-06</comp> </nuclide> 
+    <nuclide> <id>Sb122</id>  <comp>9.94414127467971e-09</comp> </nuclide> 
+    <nuclide> <id>Sb124</id>  <comp>1.0009135662095918e-06</comp> </nuclide> 
+    <nuclide> <id>Sb125</id>  <comp>8.969225463436604e-05</comp> </nuclide> 
+    <nuclide> <id>Te132</id>  <comp>0.003197723860877397</comp> </nuclide> 
+    <nuclide> <id>I129</id>  <comp>0.0008514264751523151</comp> </nuclide> 
+    <nuclide> <id>I131</id>  <comp>0.0026582704453228774</comp> </nuclide> 
+    <nuclide> <id>I133</id>  <comp>0.004543107680392888</comp> </nuclide> 
+    <nuclide> <id>I135</id>  <comp>0.004055649774771334</comp> </nuclide> 
+    <nuclide> <id>Xe128</id>  <comp>1.6248596854051817e-09</comp> </nuclide> 
+    <nuclide> <id>Xe130</id>  <comp>1.5013703493143878e-06</comp> </nuclide> 
+    <nuclide> <id>Xe131m</id>  <comp>2.8857508012796026e-05</comp> </nuclide>
+    <nuclide> <id>Xe133</id>  <comp>0.0045691054353593705</comp> </nuclide> 
+    <nuclide> <id>Xe133m</id>  <comp>0.0001449374839381422</comp> </nuclide> 
+    <nuclide> <id>Xe135</id>  <comp>0.004874579056215545</comp> </nuclide> 
+    <nuclide> <id>Xe135m</id>  <comp>0.001280389432099283</comp> </nuclide> 
+    <nuclide> <id>Cs134</id>  <comp>7.474354552863835e-07</comp> </nuclide> 
+    <nuclide> <id>Cs137</id>  <comp>0.004127143600929161</comp> </nuclide> 
+    <nuclide> <id>Ba140</id>  <comp>0.0034466523646814714</comp> </nuclide> 
+    <nuclide> <id>La140</id>  <comp>0.0034603011860388747</comp> </nuclide> 
+    <nuclide> <id>Ce141</id>  <comp>0.003256218809551984</comp> </nuclide> 
+    <nuclide> <id>Ce144</id>  <comp>0.0022774033350639027</comp> </nuclide> 
+    <nuclide> <id>Pr144</id>  <comp>0.0022780532789380644</comp> </nuclide> 
+    <nuclide> <id>Nd142</id>  <comp>1.6313591241468025e-09</comp> </nuclide> 
+    <nuclide> <id>Nd144</id>  <comp>0.0022780532789380644</comp> </nuclide> 
+    <nuclide> <id>Nd147</id>  <comp>0.0012537417332586383</comp> </nuclide> 
+    <nuclide> <id>Pm147</id>  <comp>0.0012537417332586383</comp> </nuclide> 
+    <nuclide> <id>Pm148</id>  <comp>7.799326489944873e-09</comp> </nuclide> 
+    <nuclide> <id>Pm148m</id>  <comp>1.8848372350700106e-08</comp> </nuclide>
+    <nuclide> <id>Pm149</id>  <comp>0.0008286784395566425</comp> </nuclide> 
+    <nuclide> <id>Pm151</id>  <comp>0.0005173553238330098</comp> </nuclide> 
+    <nuclide> <id>Sm148</id>  <comp>2.5347811092320833e-08</comp> </nuclide> 
+    <nuclide> <id>Sm150</id>  <comp>3.3147137582265707e-06</comp> </nuclide> 
+    <nuclide> <id>Sm151</id>  <comp>0.000518005267707172</comp> </nuclide> 
+    <nuclide> <id>Sm153</id>  <comp>0.00025997754966482906</comp> </nuclide> 
+    <nuclide> <id>Eu151</id>  <comp>0.000518005267707172</comp> </nuclide> 
+    <nuclide> <id>Eu152</id>  <comp>3.119730595977948e-10</comp> </nuclide> 
+    <nuclide> <id>Eu154</id>  <comp>8.254287201858323e-08</comp> </nuclide> 
+    <nuclide> <id>Eu155</id>  <comp>0.00011114040248171444</comp> </nuclide> 
+    <nuclide> <id>Pu238</id>  <comp>0.001164798127359022</comp> </nuclide> 
+    <nuclide> <id>Pu239</id>  <comp>0.09908368059417465</comp> </nuclide> 
+    <nuclide> <id>Pu240</id>  <comp>0.03249349929635785</comp> </nuclide> 
+    <nuclide> <id>Pu241</id>  <comp>0.0036243096344423897</comp> </nuclide> 
+    <nuclide> <id>Pu242</id>  <comp>0.0018210459910484378</comp> </nuclide> 
+    <nuclide> <id>Pu244</id>  <comp>6.35661764e-09</comp> </nuclide> 
+    <nuclide> <id>U232</id>  <comp>7.648700297471588e-09</comp> </nuclide> 
+    <nuclide> <id>U233</id>  <comp>5.285846459910117e-09</comp> </nuclide> 
+    <nuclide> <id>U234</id>  <comp>0.000155564910542954</comp> </nuclide> 
+    <nuclide> <id>U235</id>  <comp>0.00019082224532527</comp> </nuclide> 
+    <nuclide> <id>U236</id>  <comp>0.000300080729799828</comp> </nuclide> 
+    <nuclide> <id>U238</id>  <comp>0.7726661792000105</comp> </nuclide> 
+</recipe>
+"""
+
+region = {}
+
+for calc_method in calc_methods:
+    region[calc_method]= """
+    <region>
+        <config>
+            <NullRegion>
+            </NullRegion>
+        </config>
+
+        <institution> 
+            <name>lwr_inst</name>
+            <config>
+            <DeployInst>
+            <prototypes>
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val>
+                <val>lwr</val> 
+                <val>lwr</val>
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+                <val>lwr</val> 
+            </prototypes> 
+            <build_times>
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val>
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+                <val>1</val> 
+            </build_times> 
+            <n_build>
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+                <val>3</val> 
+            </n_build> 
+            <lifetimes>
+                <val>960</val> 
+                <val>970</val> 
+                <val>980</val> 
+                <val>990</val> 
+                <val>1000</val> 
+                <val>1010</val> 
+                <val>1020</val> 
+                <val>1030</val> 
+                <val>1040</val> 
+                <val>1050</val>
+                <val>1060</val> 
+                <val>1070</val> 
+                <val>1080</val> 
+                <val>1090</val> 
+                <val>1100</val> 
+                <val>1110</val> 
+                <val>1120</val> 
+                <val>1130</val> 
+                <val>1140</val> 
+                <val>1150</val> 
+            </lifetimes>
+            </DeployInst>
+            </config>
+        </institution>
+
+        <institution>
+        <config>
+        <DemandDrivenDeploymentInst>
+            <calc_method>%s</calc_method>
+            <demand_eq>%s</demand_eq>
+            <facility_commod>
+            <item>
+              <facility>source</facility>
+              <commod>sourceout</commod>
+            </item>
+            <item>
+              <facility>enrichment</facility>
+              <commod>enrichmentout</commod>
+            </item>
+            <item>
+              <facility>fr</facility>
+              <commod>POWER</commod>
+            </item>
+            </facility_commod>
+            <facility_capacity>
+            <item>
+              <facility>source</facility>
+              <capacity>1e9</capacity>
+            </item>    
+            <item>
+              <facility>enrichment</facility>
+              <capacity>1e100</capacity>
+            </item>
+            <item>
+              <facility>fr</facility>
+              <capacity>333.34</capacity>
+            </item>
+            </facility_capacity>
+            <facility_pref>
+            <item>
+              <facility>fr</facility>
+              <pref>t-959</pref>
+            </item>
+            </facility_pref>
+            <buffer_type>
+            <item>
+              <commod>POWER</commod>
+              <type>float</type>
+            </item>
+            </buffer_type>
+            <supply_buffer>
+            <item>
+              <commod>POWER</commod>
+              <buffer>%s</buffer>
+            </item>
+            </supply_buffer>
+        </DemandDrivenDeploymentInst>
+        </config>
+        <name>timeseriesinst</name>
+        </institution>
+
+        <institution>
+        <config>
+        <SupplyDrivenDeploymentInst>
+            <calc_method>%s</calc_method>
+            <facility_commod>
+            <item>
+                <facility>lwrreprocessing</facility>
+                <commod>lwrstorageout</commod>
+            </item>
+            <item>
+                <facility>frreprocessing</facility>
+                <commod>frstorageout</commod>
+            </item>
+            <item>
+                <facility>lwrmixer</facility>
+                <commod>lwrtru</commod>
+            </item>
+            <item>
+                <facility>frmixer</facility>
+                <commod>frtru</commod>
+            </item>
+            <item>
+                <facility>lwrstorage</facility>
+                <commod>lwrout</commod>
+            </item>
+            <item>
+                <facility>frstorage</facility>
+                <commod>frout</commod>
+            </item>
+            <item>
+                <facility>lwrsink</facility>
+                <commod>lwrreprocessingwaste</commod>
+            </item>
+            <item>
+                <facility>frsink</facility>
+                <commod>frreprocessingwaste</commod>
+            </item>
+            </facility_commod>
+            <facility_capacity>
+            <item>
+                <facility>lwrreprocessing</facility>
+                <capacity>1e8</capacity>
+            </item>
+            <item>
+                <facility>frreprocessing</facility>
+                <capacity>1e8</capacity>
+            </item>
+            <item>
+                <facility>lwrmixer</facility>
+                <capacity>1e6</capacity>
+            </item>
+            <item>
+                <facility>frmixer</facility>
+                <capacity>1e6</capacity>
+            </item>
+            <item>
+                <facility>lwrstorage</facility>
+                <capacity>1e7</capacity>
+            </item>
+            <item>
+                <facility>frstorage</facility>
+                <capacity>1e7</capacity>
+            </item>
+            <item>
+                <facility>lwrsink</facility>
+                <capacity>1e10</capacity>
+            </item>
+            <item>
+                <facility>frsink</facility>
+                <capacity>1e10</capacity>
+            </item>
+            </facility_capacity>
+        </SupplyDrivenDeploymentInst>
+        </config>
+        <name>supplydrivendeploymentinst</name>
+        </institution>
+
+        <name>SingleRegion</name>
+    </region>
+    """%(calc_method, demand_eq, buff_size, calc_method)
+
+for calc_method in calc_methods:
+
+    input_file = 'eg01-eg24-flatpower-d3ploy-buffer' + buff_size + '-' + calc_method + '.xml'
+    output_file = 'eg01-eg24-flatpower-d3ploy-buffer' + buff_size + '-' + calc_method + '.sqlite'
+
+    with open(input_file, 'w') as f:
+        f.write('<simulation>\n')
+        f.write(control)
+        f.write(region[calc_method])
+        f.write(recipes)
+        f.write('</simulation>')
+
+    s = subprocess.check_output(['cyclus', '-o', output_file, input_file],
+                            universal_newlines=True, env=ENV)
+

--- a/input/eg01-eg24/flatpower_d3ploy.py
+++ b/input/eg01-eg24/flatpower_d3ploy.py
@@ -351,7 +351,7 @@ control = """
                         <item>
                             <commodity>lwrtru</commodity>
                             <pref>1.0</pref>
-                        </item>          
+                        </item>
                     </commodities>
                 </stream>
                 <stream>
@@ -363,7 +363,7 @@ control = """
                         <item>
                             <commodity>lwru</commodity>
                             <pref>1.0</pref>
-                        </item>                    
+                        </item>
                     </commodities>
                 </stream>
                 <stream>
@@ -400,7 +400,7 @@ control = """
                         <item>
                             <commodity>frtru</commodity>
                             <pref>1.0</pref>
-                        </item>          
+                        </item>
                     </commodities>
                 </stream>
                 <stream>
@@ -467,180 +467,180 @@ recipes = """
     <nuclide> <id>U235</id> <comp>0.711</comp> </nuclide>
     <nuclide> <id>U238</id> <comp>99.289</comp> </nuclide>
 </recipe>
- 
+
 <recipe>
     <name>lwrinrecipe</name>
     <basis>mass</basis>
-    <nuclide> <id>U234</id>  <comp>0.0002558883</comp> </nuclide> 
-    <nuclide> <id>U235</id>  <comp>0.0319885317</comp> </nuclide> 
-    <nuclide> <id>U238</id>  <comp>0.96775558</comp> </nuclide> 
-</recipe> 
+    <nuclide> <id>U234</id>  <comp>0.0002558883</comp> </nuclide>
+    <nuclide> <id>U235</id>  <comp>0.0319885317</comp> </nuclide>
+    <nuclide> <id>U238</id>  <comp>0.96775558</comp> </nuclide>
+</recipe>
 
 <recipe>
     <name>lwroutrecipe</name>
     <basis>mass</basis>
-    <nuclide> <id>He4</id>  <comp>9.47457840128509E-07</comp> </nuclide> 
-    <nuclide> <id>Ra226</id>  <comp>9.78856442957042E-14</comp> </nuclide> 
-    <nuclide> <id>Ra228</id>  <comp>2.75087759176098E-20</comp> </nuclide> 
-    <nuclide> <id>Pb206</id>  <comp>5.57475193532078E-18</comp> </nuclide> 
-    <nuclide> <id>Pb207</id>  <comp>1.68592497990149E-15</comp> </nuclide> 
-    <nuclide> <id>Pb208</id>  <comp>3.6888358546006E-12</comp> </nuclide> 
-    <nuclide> <id>Pb210</id>  <comp>3.02386544437848E-19</comp> </nuclide> 
-    <nuclide> <id>Th228</id>  <comp>8.47562285269577E-12</comp> </nuclide> 
-    <nuclide> <id>Th229</id>  <comp>2.72787861516683E-12</comp> </nuclide> 
-    <nuclide> <id>Th230</id>  <comp>2.6258831537493E-09</comp> </nuclide> 
-    <nuclide> <id>Th232</id>  <comp>4.17481422959E-10</comp> </nuclide> 
-    <nuclide> <id>Bi209</id>  <comp>6.60770597104927E-16</comp> </nuclide> 
-    <nuclide> <id>Ac227</id>  <comp>3.0968621961773E-14</comp> </nuclide> 
-    <nuclide> <id>Pa231</id>  <comp>9.24658854635179E-10</comp> </nuclide> 
-    <nuclide> <id>U232</id>  <comp>0.000000001</comp> </nuclide> 
-    <nuclide> <id>U233</id>  <comp>2.21390148606282E-09</comp> </nuclide> 
-    <nuclide> <id>U234</id>  <comp>0.0001718924</comp> </nuclide> 
-    <nuclide> <id>U235</id>  <comp>0.0076486597</comp> </nuclide> 
-    <nuclide> <id>U236</id>  <comp>0.0057057461</comp> </nuclide> 
-    <nuclide> <id>U238</id>  <comp>0.9208590237</comp> </nuclide> 
-    <nuclide> <id>Np237</id>  <comp>0.0006091729</comp> </nuclide> 
-    <nuclide> <id>Pu238</id>  <comp>0.000291487</comp> </nuclide> 
-    <nuclide> <id>Pu239</id>  <comp>0.0060657301</comp> </nuclide> 
-    <nuclide> <id>Pu240</id>  <comp>0.0029058707</comp> </nuclide> 
-    <nuclide> <id>Pu241</id>  <comp>0.0017579218</comp> </nuclide> 
-    <nuclide> <id>Pu242</id>  <comp>0.0008638616</comp> </nuclide> 
-    <nuclide> <id>Pu244</id>  <comp>2.86487251922763E-08</comp> </nuclide> 
-    <nuclide> <id>Am241</id>  <comp>6.44271331287386E-05</comp> </nuclide> 
-    <nuclide> <id>Am242m</id>  <comp>8.53362027193319E-07</comp> </nuclide> 
-    <nuclide> <id>Am243</id>  <comp>0.0001983912</comp> </nuclide> 
-    <nuclide> <id>Cm242</id>  <comp>2.58988475560194E-05</comp> </nuclide> 
-    <nuclide> <id>Cm243</id>  <comp>0.000000771</comp> </nuclide> 
-    <nuclide> <id>Cm244</id>  <comp>8.5616190260478E-05</comp> </nuclide> 
-    <nuclide> <id>Cm245</id>  <comp>5.72174539442251E-06</comp> </nuclide> 
-    <nuclide> <id>Cm246</id>  <comp>7.29567535786554E-07</comp> </nuclide> 
-    <nuclide> <id>Cm247</id>  <comp>0.00000001</comp> </nuclide> 
-    <nuclide> <id>Cm248</id>  <comp>7.69165773748653E-10</comp> </nuclide> 
-    <nuclide> <id>Cm250</id>  <comp>4.2808095130239E-18</comp> </nuclide> 
-    <nuclide> <id>Cf249</id>  <comp>1.64992658175413E-12</comp> </nuclide> 
-    <nuclide> <id>Cf250</id>  <comp>2.04190913935875E-12</comp> </nuclide> 
-    <nuclide> <id>Cf251</id>  <comp>9.86556100338561E-13</comp> </nuclide> 
-    <nuclide> <id>Cf252</id>  <comp>6.57970721693466E-13</comp> </nuclide> 
-    <nuclide> <id>H3</id>  <comp>8.58461800264195E-08</comp> </nuclide> 
-    <nuclide> <id>C14</id>  <comp>4.05781943561107E-11</comp> </nuclide> 
-    <nuclide> <id>Kr81</id>  <comp>4.21681236076192E-11</comp> </nuclide> 
-    <nuclide> <id>Kr85</id>  <comp>3.44484671160181E-05</comp> </nuclide> 
-    <nuclide> <id>Sr90</id>  <comp>0.0007880649</comp> </nuclide> 
-    <nuclide> <id>Tc99</id>  <comp>0.0011409492</comp> </nuclide> 
-    <nuclide> <id>I129</id>  <comp>0.0002731878</comp> </nuclide> 
-    <nuclide> <id>Cs134</id>  <comp>0.0002300898</comp> </nuclide> 
-    <nuclide> <id>Cs135</id>  <comp>0.0006596706</comp> </nuclide> 
-    <nuclide> <id>Cs137</id>  <comp>0.0018169192</comp> </nuclide> 
-    <nuclide> <id>H1</id>  <comp>0.0477938151</comp> </nuclide> 
+    <nuclide> <id>He4</id>  <comp>9.47457840128509E-07</comp> </nuclide>
+    <nuclide> <id>Ra226</id>  <comp>9.78856442957042E-14</comp> </nuclide>
+    <nuclide> <id>Ra228</id>  <comp>2.75087759176098E-20</comp> </nuclide>
+    <nuclide> <id>Pb206</id>  <comp>5.57475193532078E-18</comp> </nuclide>
+    <nuclide> <id>Pb207</id>  <comp>1.68592497990149E-15</comp> </nuclide>
+    <nuclide> <id>Pb208</id>  <comp>3.6888358546006E-12</comp> </nuclide>
+    <nuclide> <id>Pb210</id>  <comp>3.02386544437848E-19</comp> </nuclide>
+    <nuclide> <id>Th228</id>  <comp>8.47562285269577E-12</comp> </nuclide>
+    <nuclide> <id>Th229</id>  <comp>2.72787861516683E-12</comp> </nuclide>
+    <nuclide> <id>Th230</id>  <comp>2.6258831537493E-09</comp> </nuclide>
+    <nuclide> <id>Th232</id>  <comp>4.17481422959E-10</comp> </nuclide>
+    <nuclide> <id>Bi209</id>  <comp>6.60770597104927E-16</comp> </nuclide>
+    <nuclide> <id>Ac227</id>  <comp>3.0968621961773E-14</comp> </nuclide>
+    <nuclide> <id>Pa231</id>  <comp>9.24658854635179E-10</comp> </nuclide>
+    <nuclide> <id>U232</id>  <comp>0.000000001</comp> </nuclide>
+    <nuclide> <id>U233</id>  <comp>2.21390148606282E-09</comp> </nuclide>
+    <nuclide> <id>U234</id>  <comp>0.0001718924</comp> </nuclide>
+    <nuclide> <id>U235</id>  <comp>0.0076486597</comp> </nuclide>
+    <nuclide> <id>U236</id>  <comp>0.0057057461</comp> </nuclide>
+    <nuclide> <id>U238</id>  <comp>0.9208590237</comp> </nuclide>
+    <nuclide> <id>Np237</id>  <comp>0.0006091729</comp> </nuclide>
+    <nuclide> <id>Pu238</id>  <comp>0.000291487</comp> </nuclide>
+    <nuclide> <id>Pu239</id>  <comp>0.0060657301</comp> </nuclide>
+    <nuclide> <id>Pu240</id>  <comp>0.0029058707</comp> </nuclide>
+    <nuclide> <id>Pu241</id>  <comp>0.0017579218</comp> </nuclide>
+    <nuclide> <id>Pu242</id>  <comp>0.0008638616</comp> </nuclide>
+    <nuclide> <id>Pu244</id>  <comp>2.86487251922763E-08</comp> </nuclide>
+    <nuclide> <id>Am241</id>  <comp>6.44271331287386E-05</comp> </nuclide>
+    <nuclide> <id>Am242m</id>  <comp>8.53362027193319E-07</comp> </nuclide>
+    <nuclide> <id>Am243</id>  <comp>0.0001983912</comp> </nuclide>
+    <nuclide> <id>Cm242</id>  <comp>2.58988475560194E-05</comp> </nuclide>
+    <nuclide> <id>Cm243</id>  <comp>0.000000771</comp> </nuclide>
+    <nuclide> <id>Cm244</id>  <comp>8.5616190260478E-05</comp> </nuclide>
+    <nuclide> <id>Cm245</id>  <comp>5.72174539442251E-06</comp> </nuclide>
+    <nuclide> <id>Cm246</id>  <comp>7.29567535786554E-07</comp> </nuclide>
+    <nuclide> <id>Cm247</id>  <comp>0.00000001</comp> </nuclide>
+    <nuclide> <id>Cm248</id>  <comp>7.69165773748653E-10</comp> </nuclide>
+    <nuclide> <id>Cm250</id>  <comp>4.2808095130239E-18</comp> </nuclide>
+    <nuclide> <id>Cf249</id>  <comp>1.64992658175413E-12</comp> </nuclide>
+    <nuclide> <id>Cf250</id>  <comp>2.04190913935875E-12</comp> </nuclide>
+    <nuclide> <id>Cf251</id>  <comp>9.86556100338561E-13</comp> </nuclide>
+    <nuclide> <id>Cf252</id>  <comp>6.57970721693466E-13</comp> </nuclide>
+    <nuclide> <id>H3</id>  <comp>8.58461800264195E-08</comp> </nuclide>
+    <nuclide> <id>C14</id>  <comp>4.05781943561107E-11</comp> </nuclide>
+    <nuclide> <id>Kr81</id>  <comp>4.21681236076192E-11</comp> </nuclide>
+    <nuclide> <id>Kr85</id>  <comp>3.44484671160181E-05</comp> </nuclide>
+    <nuclide> <id>Sr90</id>  <comp>0.0007880649</comp> </nuclide>
+    <nuclide> <id>Tc99</id>  <comp>0.0011409492</comp> </nuclide>
+    <nuclide> <id>I129</id>  <comp>0.0002731878</comp> </nuclide>
+    <nuclide> <id>Cs134</id>  <comp>0.0002300898</comp> </nuclide>
+    <nuclide> <id>Cs135</id>  <comp>0.0006596706</comp> </nuclide>
+    <nuclide> <id>Cs137</id>  <comp>0.0018169192</comp> </nuclide>
+    <nuclide> <id>H1</id>  <comp>0.0477938151</comp> </nuclide>
 </recipe> 
 
 <recipe>
     <name>frinrecipe</name>
     <basis>mass</basis>
-    <nuclide> <id>He4</id>  <comp>8.12E-11</comp> </nuclide> 
-    <nuclide> <id>U232</id>  <comp>4.71E-09</comp> </nuclide> 
-    <nuclide> <id>U234</id>  <comp>0.0003</comp> </nuclide> 
-    <nuclide> <id>U235</id>  <comp>0.0004</comp> </nuclide> 
-    <nuclide> <id>U236</id>  <comp>0.0003</comp> </nuclide> 
-    <nuclide> <id>U238</id>  <comp>0.83</comp> </nuclide> 
-    <nuclide> <id>Np237</id>  <comp>0.0007</comp> </nuclide> 
-    <nuclide> <id>Pu238</id>  <comp>0.0022</comp> </nuclide> 
-    <nuclide> <id>Pu239</id>  <comp>0.0947</comp> </nuclide> 
-    <nuclide> <id>Pu240</id>  <comp>0.0518</comp> </nuclide> 
-    <nuclide> <id>Pu241</id>  <comp>0.0072</comp> </nuclide> 
-    <nuclide> <id>Pu242</id>  <comp>0.0057</comp> </nuclide> 
-    <nuclide> <id>Am241</id>  <comp>0.0031</comp> </nuclide> 
-    <nuclide> <id>Am242m</id>  <comp>0.0002</comp> </nuclide> 
-    <nuclide> <id>Am243</id>  <comp>0.0016</comp> </nuclide> 
-    <nuclide> <id>Cm242</id>  <comp>0.0000</comp> </nuclide> 
-    <nuclide> <id>Cm243</id>  <comp>0.0000</comp> </nuclide> 
-    <nuclide> <id>Cm244</id>  <comp>0.0011</comp> </nuclide> 
-    <nuclide> <id>Cm245</id>  <comp>0.0003</comp> </nuclide> 
-    <nuclide> <id>Cm246</id>  <comp>0.0001</comp> </nuclide> 
+    <nuclide> <id>He4</id>  <comp>8.12E-11</comp> </nuclide>
+    <nuclide> <id>U232</id>  <comp>4.71E-09</comp> </nuclide>
+    <nuclide> <id>U234</id>  <comp>0.0003</comp> </nuclide>
+    <nuclide> <id>U235</id>  <comp>0.0004</comp> </nuclide>
+    <nuclide> <id>U236</id>  <comp>0.0003</comp> </nuclide>
+    <nuclide> <id>U238</id>  <comp>0.83</comp> </nuclide>
+    <nuclide> <id>Np237</id>  <comp>0.0007</comp> </nuclide>
+    <nuclide> <id>Pu238</id>  <comp>0.0022</comp> </nuclide>
+    <nuclide> <id>Pu239</id>  <comp>0.0947</comp> </nuclide>
+    <nuclide> <id>Pu240</id>  <comp>0.0518</comp> </nuclide>
+    <nuclide> <id>Pu241</id>  <comp>0.0072</comp> </nuclide>
+    <nuclide> <id>Pu242</id>  <comp>0.0057</comp> </nuclide>
+    <nuclide> <id>Am241</id>  <comp>0.0031</comp> </nuclide>
+    <nuclide> <id>Am242m</id>  <comp>0.0002</comp> </nuclide>
+    <nuclide> <id>Am243</id>  <comp>0.0016</comp> </nuclide>
+    <nuclide> <id>Cm242</id>  <comp>0.0000</comp> </nuclide>
+    <nuclide> <id>Cm243</id>  <comp>0.0000</comp> </nuclide>
+    <nuclide> <id>Cm244</id>  <comp>0.0011</comp> </nuclide>
+    <nuclide> <id>Cm245</id>  <comp>0.0003</comp> </nuclide>
+    <nuclide> <id>Cm246</id>  <comp>0.0001</comp> </nuclide>
 </recipe>
 
 <recipe>
     <name>froutrecipe</name>
     <basis>mass</basis>
-    <nuclide> <id>H1</id>  <comp>2.2488058046007715e-06</comp> </nuclide> 
-    <nuclide> <id>H2</id>  <comp>6.889405066117969e-07</comp> </nuclide> 
-    <nuclide> <id>H3</id>  <comp>9.22920301310143e-06</comp> </nuclide> 
-    <nuclide> <id>He3</id>  <comp>9.22920301310143e-06</comp> </nuclide> 
-    <nuclide> <id>He4</id>  <comp>0.00014233770844149392</comp> </nuclide> 
-    <nuclide> <id>Br85</id>  <comp>0.0004010153703579988</comp> </nuclide> 
-    <nuclide> <id>Kr82</id>  <comp>3.5746913078914e-07</comp> </nuclide> 
-    <nuclide> <id>Kr85</id>  <comp>8.969225463436604e-05</comp> </nuclide> 
-    <nuclide> <id>Kr85m</id>  <comp>0.0004010153703579988</comp> </nuclide> 
-    <nuclide> <id>Sr90</id>  <comp>0.0013200360084231696</comp> </nuclide> 
-    <nuclide> <id>Zr95</id>  <comp>0.003043037218826824</comp> </nuclide> 
-    <nuclide> <id>Nb94</id>  <comp>1.6573568791132852e-09</comp> </nuclide> 
-    <nuclide> <id>Nb95</id>  <comp>0.0030417373310784998</comp> </nuclide> 
-    <nuclide> <id>Nb95m</id>  <comp>3.288716003260088e-05</comp> </nuclide> 
-    <nuclide> <id>Mo94</id>  <comp>3.1197305959779486e-12</comp> </nuclide> 
-    <nuclide> <id>Mo96</id>  <comp>1.1049045860755233e-06</comp> </nuclide> 
-    <nuclide> <id>Mo99</id>  <comp>0.0037826733476232634</comp> </nuclide> 
-    <nuclide> <id>Tc99</id>  <comp>0.0037826733476232634</comp> </nuclide> 
-    <nuclide> <id>Ru103</id>  <comp>0.004283130130728059</comp> </nuclide> 
-    <nuclide> <id>Ru106</id>  <comp>0.00268426820028936</comp> </nuclide> 
-    <nuclide> <id>Rh106</id>  <comp>0.00268426820028936</comp> </nuclide> 
-    <nuclide> <id>Sn121m</id>  <comp>3.444702533058985e-06</comp> </nuclide> 
-    <nuclide> <id>Sb122</id>  <comp>9.94414127467971e-09</comp> </nuclide> 
-    <nuclide> <id>Sb124</id>  <comp>1.0009135662095918e-06</comp> </nuclide> 
-    <nuclide> <id>Sb125</id>  <comp>8.969225463436604e-05</comp> </nuclide> 
-    <nuclide> <id>Te132</id>  <comp>0.003197723860877397</comp> </nuclide> 
-    <nuclide> <id>I129</id>  <comp>0.0008514264751523151</comp> </nuclide> 
-    <nuclide> <id>I131</id>  <comp>0.0026582704453228774</comp> </nuclide> 
-    <nuclide> <id>I133</id>  <comp>0.004543107680392888</comp> </nuclide> 
-    <nuclide> <id>I135</id>  <comp>0.004055649774771334</comp> </nuclide> 
-    <nuclide> <id>Xe128</id>  <comp>1.6248596854051817e-09</comp> </nuclide> 
-    <nuclide> <id>Xe130</id>  <comp>1.5013703493143878e-06</comp> </nuclide> 
+    <nuclide> <id>H1</id>  <comp>2.2488058046007715e-06</comp> </nuclide>
+    <nuclide> <id>H2</id>  <comp>6.889405066117969e-07</comp> </nuclide>
+    <nuclide> <id>H3</id>  <comp>9.22920301310143e-06</comp> </nuclide>
+    <nuclide> <id>He3</id>  <comp>9.22920301310143e-06</comp> </nuclide>
+    <nuclide> <id>He4</id>  <comp>0.00014233770844149392</comp> </nuclide>
+    <nuclide> <id>Br85</id>  <comp>0.0004010153703579988</comp> </nuclide>
+    <nuclide> <id>Kr82</id>  <comp>3.5746913078914e-07</comp> </nuclide>
+    <nuclide> <id>Kr85</id>  <comp>8.969225463436604e-05</comp> </nuclide>
+    <nuclide> <id>Kr85m</id>  <comp>0.0004010153703579988</comp> </nuclide>
+    <nuclide> <id>Sr90</id>  <comp>0.0013200360084231696</comp> </nuclide>
+    <nuclide> <id>Zr95</id>  <comp>0.003043037218826824</comp> </nuclide>
+    <nuclide> <id>Nb94</id>  <comp>1.6573568791132852e-09</comp> </nuclide>
+    <nuclide> <id>Nb95</id>  <comp>0.0030417373310784998</comp> </nuclide>
+    <nuclide> <id>Nb95m</id>  <comp>3.288716003260088e-05</comp> </nuclide>
+    <nuclide> <id>Mo94</id>  <comp>3.1197305959779486e-12</comp> </nuclide>
+    <nuclide> <id>Mo96</id>  <comp>1.1049045860755233e-06</comp> </nuclide>
+    <nuclide> <id>Mo99</id>  <comp>0.0037826733476232634</comp> </nuclide>
+    <nuclide> <id>Tc99</id>  <comp>0.0037826733476232634</comp> </nuclide>
+    <nuclide> <id>Ru103</id>  <comp>0.004283130130728059</comp> </nuclide>
+    <nuclide> <id>Ru106</id>  <comp>0.00268426820028936</comp> </nuclide>
+    <nuclide> <id>Rh106</id>  <comp>0.00268426820028936</comp> </nuclide>
+    <nuclide> <id>Sn121m</id>  <comp>3.444702533058985e-06</comp> </nuclide>
+    <nuclide> <id>Sb122</id>  <comp>9.94414127467971e-09</comp> </nuclide>
+    <nuclide> <id>Sb124</id>  <comp>1.0009135662095918e-06</comp> </nuclide>
+    <nuclide> <id>Sb125</id>  <comp>8.969225463436604e-05</comp> </nuclide>
+    <nuclide> <id>Te132</id>  <comp>0.003197723860877397</comp> </nuclide>
+    <nuclide> <id>I129</id>  <comp>0.0008514264751523151</comp> </nuclide>
+    <nuclide> <id>I131</id>  <comp>0.0026582704453228774</comp> </nuclide>
+    <nuclide> <id>I133</id>  <comp>0.004543107680392888</comp> </nuclide>
+    <nuclide> <id>I135</id>  <comp>0.004055649774771334</comp> </nuclide>
+    <nuclide> <id>Xe128</id>  <comp>1.6248596854051817e-09</comp> </nuclide>
+    <nuclide> <id>Xe130</id>  <comp>1.5013703493143878e-06</comp> </nuclide>
     <nuclide> <id>Xe131m</id>  <comp>2.8857508012796026e-05</comp> </nuclide>
-    <nuclide> <id>Xe133</id>  <comp>0.0045691054353593705</comp> </nuclide> 
-    <nuclide> <id>Xe133m</id>  <comp>0.0001449374839381422</comp> </nuclide> 
-    <nuclide> <id>Xe135</id>  <comp>0.004874579056215545</comp> </nuclide> 
-    <nuclide> <id>Xe135m</id>  <comp>0.001280389432099283</comp> </nuclide> 
-    <nuclide> <id>Cs134</id>  <comp>7.474354552863835e-07</comp> </nuclide> 
-    <nuclide> <id>Cs137</id>  <comp>0.004127143600929161</comp> </nuclide> 
-    <nuclide> <id>Ba140</id>  <comp>0.0034466523646814714</comp> </nuclide> 
-    <nuclide> <id>La140</id>  <comp>0.0034603011860388747</comp> </nuclide> 
-    <nuclide> <id>Ce141</id>  <comp>0.003256218809551984</comp> </nuclide> 
-    <nuclide> <id>Ce144</id>  <comp>0.0022774033350639027</comp> </nuclide> 
-    <nuclide> <id>Pr144</id>  <comp>0.0022780532789380644</comp> </nuclide> 
-    <nuclide> <id>Nd142</id>  <comp>1.6313591241468025e-09</comp> </nuclide> 
-    <nuclide> <id>Nd144</id>  <comp>0.0022780532789380644</comp> </nuclide> 
-    <nuclide> <id>Nd147</id>  <comp>0.0012537417332586383</comp> </nuclide> 
-    <nuclide> <id>Pm147</id>  <comp>0.0012537417332586383</comp> </nuclide> 
-    <nuclide> <id>Pm148</id>  <comp>7.799326489944873e-09</comp> </nuclide> 
+    <nuclide> <id>Xe133</id>  <comp>0.0045691054353593705</comp> </nuclide>
+    <nuclide> <id>Xe133m</id>  <comp>0.0001449374839381422</comp> </nuclide>
+    <nuclide> <id>Xe135</id>  <comp>0.004874579056215545</comp> </nuclide>
+    <nuclide> <id>Xe135m</id>  <comp>0.001280389432099283</comp> </nuclide>
+    <nuclide> <id>Cs134</id>  <comp>7.474354552863835e-07</comp> </nuclide>
+    <nuclide> <id>Cs137</id>  <comp>0.004127143600929161</comp> </nuclide>
+    <nuclide> <id>Ba140</id>  <comp>0.0034466523646814714</comp> </nuclide>
+    <nuclide> <id>La140</id>  <comp>0.0034603011860388747</comp> </nuclide>
+    <nuclide> <id>Ce141</id>  <comp>0.003256218809551984</comp> </nuclide>
+    <nuclide> <id>Ce144</id>  <comp>0.0022774033350639027</comp> </nuclide>
+    <nuclide> <id>Pr144</id>  <comp>0.0022780532789380644</comp> </nuclide>
+    <nuclide> <id>Nd142</id>  <comp>1.6313591241468025e-09</comp> </nuclide>
+    <nuclide> <id>Nd144</id>  <comp>0.0022780532789380644</comp> </nuclide>
+    <nuclide> <id>Nd147</id>  <comp>0.0012537417332586383</comp> </nuclide>
+    <nuclide> <id>Pm147</id>  <comp>0.0012537417332586383</comp> </nuclide>
+    <nuclide> <id>Pm148</id>  <comp>7.799326489944873e-09</comp> </nuclide>
     <nuclide> <id>Pm148m</id>  <comp>1.8848372350700106e-08</comp> </nuclide>
-    <nuclide> <id>Pm149</id>  <comp>0.0008286784395566425</comp> </nuclide> 
-    <nuclide> <id>Pm151</id>  <comp>0.0005173553238330098</comp> </nuclide> 
-    <nuclide> <id>Sm148</id>  <comp>2.5347811092320833e-08</comp> </nuclide> 
-    <nuclide> <id>Sm150</id>  <comp>3.3147137582265707e-06</comp> </nuclide> 
-    <nuclide> <id>Sm151</id>  <comp>0.000518005267707172</comp> </nuclide> 
-    <nuclide> <id>Sm153</id>  <comp>0.00025997754966482906</comp> </nuclide> 
-    <nuclide> <id>Eu151</id>  <comp>0.000518005267707172</comp> </nuclide> 
-    <nuclide> <id>Eu152</id>  <comp>3.119730595977948e-10</comp> </nuclide> 
-    <nuclide> <id>Eu154</id>  <comp>8.254287201858323e-08</comp> </nuclide> 
-    <nuclide> <id>Eu155</id>  <comp>0.00011114040248171444</comp> </nuclide> 
-    <nuclide> <id>Pu238</id>  <comp>0.001164798127359022</comp> </nuclide> 
-    <nuclide> <id>Pu239</id>  <comp>0.09908368059417465</comp> </nuclide> 
-    <nuclide> <id>Pu240</id>  <comp>0.03249349929635785</comp> </nuclide> 
-    <nuclide> <id>Pu241</id>  <comp>0.0036243096344423897</comp> </nuclide> 
-    <nuclide> <id>Pu242</id>  <comp>0.0018210459910484378</comp> </nuclide> 
-    <nuclide> <id>Pu244</id>  <comp>6.35661764e-09</comp> </nuclide> 
-    <nuclide> <id>U232</id>  <comp>7.648700297471588e-09</comp> </nuclide> 
-    <nuclide> <id>U233</id>  <comp>5.285846459910117e-09</comp> </nuclide> 
-    <nuclide> <id>U234</id>  <comp>0.000155564910542954</comp> </nuclide> 
-    <nuclide> <id>U235</id>  <comp>0.00019082224532527</comp> </nuclide> 
-    <nuclide> <id>U236</id>  <comp>0.000300080729799828</comp> </nuclide> 
-    <nuclide> <id>U238</id>  <comp>0.7726661792000105</comp> </nuclide> 
+    <nuclide> <id>Pm149</id>  <comp>0.0008286784395566425</comp> </nuclide>
+    <nuclide> <id>Pm151</id>  <comp>0.0005173553238330098</comp> </nuclide>
+    <nuclide> <id>Sm148</id>  <comp>2.5347811092320833e-08</comp> </nuclide>
+    <nuclide> <id>Sm150</id>  <comp>3.3147137582265707e-06</comp> </nuclide>
+    <nuclide> <id>Sm151</id>  <comp>0.000518005267707172</comp> </nuclide>
+    <nuclide> <id>Sm153</id>  <comp>0.00025997754966482906</comp> </nuclide>
+    <nuclide> <id>Eu151</id>  <comp>0.000518005267707172</comp> </nuclide>
+    <nuclide> <id>Eu152</id>  <comp>3.119730595977948e-10</comp> </nuclide>
+    <nuclide> <id>Eu154</id>  <comp>8.254287201858323e-08</comp> </nuclide>
+    <nuclide> <id>Eu155</id>  <comp>0.00011114040248171444</comp> </nuclide>
+    <nuclide> <id>Pu238</id>  <comp>0.001164798127359022</comp> </nuclide>
+    <nuclide> <id>Pu239</id>  <comp>0.09908368059417465</comp> </nuclide>
+    <nuclide> <id>Pu240</id>  <comp>0.03249349929635785</comp> </nuclide>
+    <nuclide> <id>Pu241</id>  <comp>0.0036243096344423897</comp> </nuclide>
+    <nuclide> <id>Pu242</id>  <comp>0.0018210459910484378</comp> </nuclide>
+    <nuclide> <id>Pu244</id>  <comp>6.35661764e-09</comp> </nuclide>
+    <nuclide> <id>U232</id>  <comp>7.648700297471588e-09</comp> </nuclide>
+    <nuclide> <id>U233</id>  <comp>5.285846459910117e-09</comp> </nuclide>
+    <nuclide> <id>U234</id>  <comp>0.000155564910542954</comp> </nuclide>
+    <nuclide> <id>U235</id>  <comp>0.00019082224532527</comp> </nuclide>
+    <nuclide> <id>U236</id>  <comp>0.000300080729799828</comp> </nuclide>
+    <nuclide> <id>U238</id>  <comp>0.7726661792000105</comp> </nuclide>
 </recipe>
 """
 
 region = {}
 
 for calc_method in calc_methods:
-    region[calc_method]= """
+    region[calc_method] = """
     <region>
         <config>
             <NullRegion>
@@ -652,92 +652,92 @@ for calc_method in calc_methods:
             <config>
             <DeployInst>
             <prototypes>
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
                 <val>lwr</val>
-                <val>lwr</val> 
                 <val>lwr</val>
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-                <val>lwr</val> 
-            </prototypes> 
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+                <val>lwr</val>
+            </prototypes>
             <build_times>
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
                 <val>1</val>
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-                <val>1</val> 
-            </build_times> 
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+                <val>1</val>
+            </build_times>
             <n_build>
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
-                <val>3</val> 
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
+                <val>3</val>
             </n_build> 
             <lifetimes>
-                <val>960</val> 
-                <val>970</val> 
-                <val>980</val> 
-                <val>990</val> 
-                <val>1000</val> 
-                <val>1010</val> 
-                <val>1020</val> 
-                <val>1030</val> 
-                <val>1040</val> 
+                <val>960</val>
+                <val>970</val>
+                <val>980</val>
+                <val>990</val>
+                <val>1000</val>
+                <val>1010</val>
+                <val>1020</val>
+                <val>1030</val>
+                <val>1040</val>
                 <val>1050</val>
-                <val>1060</val> 
-                <val>1070</val> 
-                <val>1080</val> 
-                <val>1090</val> 
-                <val>1100</val> 
-                <val>1110</val> 
-                <val>1120</val> 
-                <val>1130</val> 
-                <val>1140</val> 
-                <val>1150</val> 
+                <val>1060</val>
+                <val>1070</val>
+                <val>1080</val>
+                <val>1090</val>
+                <val>1100</val>
+                <val>1110</val>
+                <val>1120</val>
+                <val>1130</val>
+                <val>1140</val>
+                <val>1150</val>
             </lifetimes>
             </DeployInst>
             </config>
@@ -766,7 +766,7 @@ for calc_method in calc_methods:
             <item>
               <facility>source</facility>
               <capacity>1e9</capacity>
-            </item>    
+            </item>
             <item>
               <facility>enrichment</facility>
               <capacity>1e100</capacity>
@@ -878,12 +878,14 @@ for calc_method in calc_methods:
 
         <name>SingleRegion</name>
     </region>
-    """%(calc_method, demand_eq, buff_size, calc_method)
+    """ % (calc_method, demand_eq, buff_size, calc_method)
 
 for calc_method in calc_methods:
 
-    input_file = 'eg01-eg24-flatpower-d3ploy-buffer' + buff_size + '-' + calc_method + '.xml'
-    output_file = 'eg01-eg24-flatpower-d3ploy-buffer' + buff_size + '-' + calc_method + '.sqlite'
+    input_file = 'eg01-eg24-flatpower-d3ploy-buffer' + buff_size + '-' \
+                + calc_method + '.xml'
+    output_file = 'eg01-eg24-flatpower-d3ploy-buffer' + buff_size + '-' \
+                 + calc_method + '.sqlite'
 
     with open(input_file, 'w') as f:
         f.write('<simulation>\n')
@@ -893,5 +895,4 @@ for calc_method in calc_methods:
         f.write('</simulation>')
 
     s = subprocess.check_output(['cyclus', '-o', output_file, input_file],
-                            universal_newlines=True, env=ENV)
-
+                                universal_newlines=True, env=ENV)

--- a/input/eg01-eg24/flatpower_d3ploy_plot.py
+++ b/input/eg01-eg24/flatpower_d3ploy_plot.py
@@ -82,8 +82,8 @@ add = '-buffer2000'
 name = 'eg01-eg24-flatpower-d3ploy' + add
 
 for calc_method in calc_methods:
-    output_file = name + '-' + calc_method +'.sqlite'
- 
+    output_file = name + '-' + calc_method + '.sqlite'
+
     all_dict['power'] = tester.supply_demand_dict_driving(output_file,
                                                           demand_eq,
                                                           'power')

--- a/input/eg01-eg24/flatpower_d3ploy_plot.py
+++ b/input/eg01-eg24/flatpower_d3ploy_plot.py
@@ -30,15 +30,15 @@ def plot_several(name, all_dict, commod, calc_methods, demand_eq):
     for calc_method in calc_methods:
         dict_demand[calc_method] = all_dict[calc_method]['dict_demand']
         dict_supply[calc_method] = all_dict[calc_method]['dict_supply']
-    
+
     fig, ax = plt.subplots(figsize=(15, 7))
-    
-    ax.semilogy(*zip(*sorted(dict_demand[calc_method].items())), '-', color='red',
-            label='Demand')
-    
+
+    ax.semilogy(*zip(*sorted(dict_demand[calc_method].items())), '-',
+                color='red', label='Demand')
+
     for calc_method in calc_methods:
         ax.semilogy(*zip(*sorted(dict_supply[calc_method].items())), 'x',
-                label=calc_method + ' Supply', markersize=4) 
+                    label=calc_method + ' Supply', markersize=4)
 
     ax.set_xlabel('Time (month timestep)', fontsize=14)
     if commod.lower() == 'power':
@@ -49,23 +49,25 @@ def plot_several(name, all_dict, commod, calc_methods, demand_eq):
     handles, labels = ax.get_legend_handles_labels()
     ax.legend(handles, labels, fontsize=11, loc='upper center',
               bbox_to_anchor=(1.1, 1.0), fancybox=True)
-   
+
     plt.minorticks_off()
     ax.set_yticks(np.arange(5.8e4, 6.5e4, 2.e3))
     plt.savefig(name, dpi=300, bbox_inches='tight')
     plt.close()
 
+
 direc = os.listdir('./')
 
 # Delete previously generated files
-#hit_list = glob.glob('*.png') + glob.glob('*.csv')
-#for file in hit_list:
-#    os.remove(file)
+# hit_list = glob.glob('*.png') + glob.glob('*.csv')
+# for file in hit_list:
+#     os.remove(file)
 
 ENV = dict(os.environ)
 ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
 
-calc_methods = ["ma", "arma", "arch", "poly", "exp_smoothing", "holt_winters", "fft", "sw_seasonal"]
+calc_methods = ["ma", "arma", "arch", "poly", "exp_smoothing", "holt_winters",
+                "fft", "sw_seasonal"]
 
 demand_eq = "60000"
 
@@ -76,37 +78,39 @@ front_commods = ['sourceout', 'enrichmentout']
 back_commods = ['lwrtru', 'frtru']
 
 add = '-buffer2000'
-#add = sys.argv[1]
+# add = sys.argv[1]
 name = 'eg01-eg24-flatpower-d3ploy' + add
 
 for calc_method in calc_methods:
     output_file = name + '-' + calc_method +'.sqlite'
  
-    all_dict['power'] = tester.supply_demand_dict_driving(
-    output_file, demand_eq, 'power')
+    all_dict['power'] = tester.supply_demand_dict_driving(output_file,
+                                                          demand_eq,
+                                                          'power')
 
-    metric_dict = tester.metrics(
-        all_dict['power'], metric_dict, calc_method, 'power', True)
+    metric_dict = tester.metrics(all_dict['power'], metric_dict, calc_method,
+                                 'power', True)
 
     for commod in front_commods:
         all_dict[commod] = tester.supply_demand_dict_nondriving(output_file,
                                                                 commod, True)
-        metric_dict = tester.metrics(
-            all_dict[commod], metric_dict, calc_method, commod, True)
+        metric_dict = tester.metrics(all_dict[commod], metric_dict,
+                                     calc_method, commod, True)
 
     commod = 'mixerout'
     all_dict[commod] = tester.supply_demand_dict_nond3ploy(output_file,
                                                            commod)
 
-    metric_dict = tester.metrics(
-        all_dict[commod], metric_dict, calc_method, commod, True)
+    metric_dict = tester.metrics(all_dict[commod], metric_dict, calc_method,
+                                 commod, True)
 
     for commod in back_commods:
         all_dict[commod] = tester.supply_demand_dict_nondriving(output_file,
-                                                                commod, False)
-        metric_dict = tester.metrics(
-            all_dict[commod], metric_dict, calc_method, commod, False)
-  
+                                                                commod,
+                                                                False)
+        metric_dict = tester.metrics(all_dict[commod], metric_dict,
+                                     calc_method, commod, False)
+
     df = pd.DataFrame(metric_dict)
     df.to_csv(name + '.csv')
 
@@ -115,19 +119,28 @@ calc_methods2 = ["poly", "exp_smoothing", "holt_winters", "fft"]
 calc_methods3 = ["sw_seasonal"]
 
 for calc_method in calc_methods1:
-    output_file = name +'-'+ calc_method +'.sqlite' 
-    all_dict[calc_method] = tester.supply_demand_dict_driving(output_file, demand_eq, 'power')
+    output_file = name + '-' + calc_method + '.sqlite'
+    all_dict[calc_method] = tester.supply_demand_dict_driving(output_file,
+                                                              demand_eq,
+                                                              'power')
 
-plot_several('24-power'+ add +'1', all_dict, 'power', calc_methods1, demand_eq)
+plot_several('24-power' + add + '1', all_dict, 'power', calc_methods1,
+             demand_eq)
 
 for calc_method in calc_methods2:
-    output_file = name +'-'+ calc_method +'.sqlite' 
-    all_dict[calc_method] = tester.supply_demand_dict_driving(output_file, demand_eq, 'power')
+    output_file = name + '-' + calc_method + '.sqlite'
+    all_dict[calc_method] = tester.supply_demand_dict_driving(output_file,
+                                                              demand_eq,
+                                                              'power')
 
-plot_several('24-power'+ add +'2', all_dict, 'power', calc_methods2, demand_eq)
+plot_several('24-power' + add + '2', all_dict, 'power', calc_methods2,
+             demand_eq)
 
 for calc_method in calc_methods3:
-    output_file = name +'-'+ calc_method +'.sqlite' 
-    all_dict[calc_method] = tester.supply_demand_dict_driving(output_file, demand_eq, 'power')
+    output_file = name + '-' + calc_method + '.sqlite'
+    all_dict[calc_method] = tester.supply_demand_dict_driving(output_file,
+                                                              demand_eq,
+                                                              'power')
 
-plot_several('24-power'+ add +'3', all_dict, 'power', calc_methods3, demand_eq)
+plot_several('24-power' + add + '3', all_dict, 'power', calc_methods3,
+             demand_eq)

--- a/input/eg01-eg24/flatpower_d3ploy_plot.py
+++ b/input/eg01-eg24/flatpower_d3ploy_plot.py
@@ -1,0 +1,133 @@
+"""
+This script creates the .csv file and the .png files for power
+asociated to a scenario run with multiple calculations methods.
+
+It produces one .png for NO, one for DO, and one for SO.
+"""
+
+import json
+import re
+import subprocess
+import os
+import sqlite3 as lite
+import copy
+import glob
+import sys
+from matplotlib import pyplot as plt
+import matplotlib
+from matplotlib.ticker import ScalarFormatter, NullFormatter
+import numpy as np
+import pandas as pd
+import d3ploy.tester as tester
+import d3ploy.plotter as plotter
+import collections
+
+
+def plot_several(name, all_dict, commod, calc_methods, demand_eq):
+    dict_demand = {}
+    dict_supply = {}
+
+    for calc_method in calc_methods:
+        dict_demand[calc_method] = all_dict[calc_method]['dict_demand']
+        dict_supply[calc_method] = all_dict[calc_method]['dict_supply']
+    
+    fig, ax = plt.subplots(figsize=(15, 7))
+    
+    ax.semilogy(*zip(*sorted(dict_demand[calc_method].items())), '-', color='red',
+            label='Demand')
+    
+    for calc_method in calc_methods:
+        ax.semilogy(*zip(*sorted(dict_supply[calc_method].items())), 'x',
+                label=calc_method + ' Supply', markersize=4) 
+
+    ax.set_xlabel('Time (month timestep)', fontsize=14)
+    if commod.lower() == 'power':
+        ax.set_ylabel('Power (MW)', fontsize=14)
+    else:
+        ax.set_ylabel('Mass (Kg)', fontsize=14)
+
+    handles, labels = ax.get_legend_handles_labels()
+    ax.legend(handles, labels, fontsize=11, loc='upper center',
+              bbox_to_anchor=(1.1, 1.0), fancybox=True)
+   
+    plt.minorticks_off()
+    ax.set_yticks(np.arange(5.8e4, 6.5e4, 2.e3))
+    plt.savefig(name, dpi=300, bbox_inches='tight')
+    plt.close()
+
+direc = os.listdir('./')
+
+# Delete previously generated files
+#hit_list = glob.glob('*.png') + glob.glob('*.csv')
+#for file in hit_list:
+#    os.remove(file)
+
+ENV = dict(os.environ)
+ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
+
+calc_methods = ["ma", "arma", "arch", "poly", "exp_smoothing", "holt_winters", "fft", "sw_seasonal"]
+
+demand_eq = "60000"
+
+metric_dict = {}
+all_dict = {}
+
+front_commods = ['sourceout', 'enrichmentout']
+back_commods = ['lwrtru', 'frtru']
+
+add = '-buffer2000'
+#add = sys.argv[1]
+name = 'eg01-eg24-flatpower-d3ploy' + add
+
+for calc_method in calc_methods:
+    output_file = name + '-' + calc_method +'.sqlite'
+ 
+    all_dict['power'] = tester.supply_demand_dict_driving(
+    output_file, demand_eq, 'power')
+
+    metric_dict = tester.metrics(
+        all_dict['power'], metric_dict, calc_method, 'power', True)
+
+    for commod in front_commods:
+        all_dict[commod] = tester.supply_demand_dict_nondriving(output_file,
+                                                                commod, True)
+        metric_dict = tester.metrics(
+            all_dict[commod], metric_dict, calc_method, commod, True)
+
+    commod = 'mixerout'
+    all_dict[commod] = tester.supply_demand_dict_nond3ploy(output_file,
+                                                           commod)
+
+    metric_dict = tester.metrics(
+        all_dict[commod], metric_dict, calc_method, commod, True)
+
+    for commod in back_commods:
+        all_dict[commod] = tester.supply_demand_dict_nondriving(output_file,
+                                                                commod, False)
+        metric_dict = tester.metrics(
+            all_dict[commod], metric_dict, calc_method, commod, False)
+  
+    df = pd.DataFrame(metric_dict)
+    df.to_csv(name + '.csv')
+
+calc_methods1 = ["ma", "arma", "arch"]
+calc_methods2 = ["poly", "exp_smoothing", "holt_winters", "fft"]
+calc_methods3 = ["sw_seasonal"]
+
+for calc_method in calc_methods1:
+    output_file = name +'-'+ calc_method +'.sqlite' 
+    all_dict[calc_method] = tester.supply_demand_dict_driving(output_file, demand_eq, 'power')
+
+plot_several('24-power'+ add +'1', all_dict, 'power', calc_methods1, demand_eq)
+
+for calc_method in calc_methods2:
+    output_file = name +'-'+ calc_method +'.sqlite' 
+    all_dict[calc_method] = tester.supply_demand_dict_driving(output_file, demand_eq, 'power')
+
+plot_several('24-power'+ add +'2', all_dict, 'power', calc_methods2, demand_eq)
+
+for calc_method in calc_methods3:
+    output_file = name +'-'+ calc_method +'.sqlite' 
+    all_dict[calc_method] = tester.supply_demand_dict_driving(output_file, demand_eq, 'power')
+
+plot_several('24-power'+ add +'3', all_dict, 'power', calc_methods3, demand_eq)

--- a/input/eg01-eg24/plot_d3ploy.py
+++ b/input/eg01-eg24/plot_d3ploy.py
@@ -23,9 +23,9 @@ import collections
 direc = os.listdir('./')
 
 # Delete previously generated files
-#hit_list = glob.glob('*.png') + glob.glob('*.csv') + glob.glob('*.txt')
-#for file in hit_list:
-#    os.remove(file)
+# hit_list = glob.glob('*.png') + glob.glob('*.csv') + glob.glob('*.txt')
+# for file in hit_list:
+#     os.remove(file)
 
 ENV = dict(os.environ)
 ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
@@ -33,7 +33,7 @@ ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
 # initialize metric dict
 demand_eq = '60000'
 calc_method = 'ma'
-name = "eg01-eg24-flatpower-d3ploy-buffer2000-"+ calc_method
+name = "eg01-eg24-flatpower-d3ploy-buffer2000-" + calc_method
 output_file = name + ".sqlite"
 
 # Initialize dicts

--- a/input/eg01-eg24/plot_d3ploy.py
+++ b/input/eg01-eg24/plot_d3ploy.py
@@ -1,0 +1,95 @@
+"""
+This file produces the plots for one scenario.
+The plots are produced for only one calculation method.
+This is not useful to compare different calculation methods
+but to see the outputs of only one simulation.
+"""
+
+import json
+import re
+import subprocess
+import os
+import sqlite3 as lite
+import copy
+import glob
+import sys
+from matplotlib import pyplot as plt
+import numpy as np
+import pandas as pd
+import d3ploy.tester as tester
+import d3ploy.plotter as plotter
+import collections
+
+direc = os.listdir('./')
+
+# Delete previously generated files
+#hit_list = glob.glob('*.png') + glob.glob('*.csv') + glob.glob('*.txt')
+#for file in hit_list:
+#    os.remove(file)
+
+ENV = dict(os.environ)
+ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
+
+# initialize metric dict
+demand_eq = '60000'
+calc_method = 'ma'
+name = "eg01-eg24-flatpower-d3ploy-buffer2000-"+ calc_method
+output_file = name + ".sqlite"
+
+# Initialize dicts
+metric_dict = {}
+all_dict = {}
+agent_entry_dict = {}
+
+# get agent deployment
+commod_dict = {'enrichmentout': ['enrichment'],
+               'sourceout': ['source'],
+               'power': ['lwr', 'fr'],
+               'lwrstorageout': ['lwrreprocessing'],
+               'frstorageout': ['frreprocessing'],
+               'lwrout': ['lwrstorage'],
+               'frout': ['frstorage'],
+               'lwrtru': ['pumixerlwr'],
+               'frtru': ['pumixerfr'],
+               'lwrreprocessingwaste': ['lwrsink'],
+               'frreprocessingwaste': ['frsink']}
+
+for commod, facility in commod_dict.items():
+    agent_entry_dict[commod] = tester.get_agent_dict(output_file, facility)
+
+# get supply deamnd dict
+all_dict['power'] = tester.supply_demand_dict_driving(
+    output_file, demand_eq, 'power')
+
+plotter.plot_demand_supply_agent(all_dict['power'], agent_entry_dict['power'],
+                                 'power', 'eg01-eg24-flatpower-d3ploy_power',
+                                 True, True, False, 1)
+
+front_commods = ['sourceout', 'enrichmentout']
+back_commods = ['lwrstorageout', 'frstorageout', 'lwrout', 'frout',
+                'lwrreprocessingwaste', 'frreprocessingwaste', 'frtru',
+                'lwrtru']
+
+for commod in front_commods:
+    all_dict[commod] = tester.supply_demand_dict_nondriving(output_file,
+                                                            commod, True)
+    name = 'B2000-' + commod
+    plotter.plot_demand_supply_agent(all_dict[commod],
+                                     agent_entry_dict[commod], commod, name,
+                                     True, True, False, 1)
+    metric_dict = tester.metrics(
+        all_dict[commod], metric_dict, calc_method, commod, True)
+
+for commod in back_commods:
+    all_dict[commod] = tester.supply_demand_dict_nondriving(output_file,
+                                                            commod, False)
+
+    name = 'B2000-' + commod
+    plotter.plot_demand_supply_agent(all_dict[commod],
+                                     agent_entry_dict[commod],
+                                     commod, name, False, True, False, 1)
+    metric_dict = tester.metrics(
+        all_dict[commod], metric_dict, calc_method, commod, False)
+
+df = pd.DataFrame(metric_dict)
+df.to_csv('B2000-' + calc_method + '.csv')

--- a/input/eg01-eg24/plot_flatpower_nond3ploy.py
+++ b/input/eg01-eg24/plot_flatpower_nond3ploy.py
@@ -21,7 +21,7 @@ direc = os.listdir('./')
 # hit_list = glob.glob('*.png') + glob.glob('*.csv') + glob.glob('*.txt')
 # for file in hit_list:
 #     os.remove(file)
-  
+
 ENV = dict(os.environ)
 ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
 

--- a/input/eg01-eg24/plot_flatpower_nond3ploy.py
+++ b/input/eg01-eg24/plot_flatpower_nond3ploy.py
@@ -1,0 +1,84 @@
+# this file produces the plots for the case eg01-eg23-flatpower-d3ploy.xml
+
+import json
+import re
+import subprocess
+import os
+import sqlite3 as lite
+import copy
+import glob
+import sys
+from matplotlib import pyplot as plt
+import numpy as np
+import pandas as pd
+import d3ploy.tester as tester
+import d3ploy.plotter as plotter
+import collections
+
+direc = os.listdir('./')
+
+# Delete previously generated files
+#hit_list = glob.glob('*.png') + glob.glob('*.csv') + glob.glob('*.txt')
+#for file in hit_list:
+#    os.remove(file)
+
+ENV = dict(os.environ)
+ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
+
+# initialize metric dict
+demand_eq = '60000'
+calc_method = 'ma'
+name = "eg01-eg24-flatpower-nond3ploy"
+output_file = name + ".sqlite"
+
+# Initialize dicts
+metric_dict = {}
+all_dict = {}
+agent_entry_dict = {}
+
+# get agent deployment
+commod_dict = {'enrichmentout': ['enrichment'],
+               'sourceout': ['source'],
+               'power': ['lwr', 'fr'],
+               'lwrstorageout': ['lwrreprocessing'],
+               'frstorageout': ['frreprocessing'],
+               'lwrout': ['lwrstorage'],
+               'frout': ['frstorage'],
+               'lwrpu': ['pumixerlwr'],
+               'frpu': ['pumixerfr'],
+               'lwrreprocessingwaste': ['lwrsink'],
+               'frreprocessingwaste': ['frsink']}
+
+for commod, facility in commod_dict.items():
+    agent_entry_dict[commod] = tester.get_agent_dict(output_file, facility)
+
+# get supply deamnd dict
+all_dict['power'] = tester.supply_demand_dict_nond3ploy(
+    output_file, 'power', demand_eq)
+
+plotter.plot_demand_supply_nond3ploy(all_dict['power'],
+                                     agent_entry_dict['power'], 'power',
+                                     'eg01-eg24-flatpower-nond3ploy_power',
+                                     True, True, 1)
+
+front_commods = ['sourceout', 'enrichmentout']
+back_commods = ['lwrstorageout', 'frstorageout', 'lwrout', 'frout',
+                'lwrreprocessingwaste', 'frreprocessingwaste', 'frpu',
+                'lwrpu']
+
+for commod in front_commods:
+    all_dict[commod] = tester.supply_demand_dict_nond3ploy(output_file,
+                                                           commod)
+    name = 'eg01-eg24-flatpower-nond3ploy_' + commod
+    plotter.plot_demand_supply_nond3ploy(all_dict[commod],
+                                         agent_entry_dict[commod], commod,
+                                         name, True, True, 1)
+
+for commod in back_commods:
+    all_dict[commod] = tester.supply_demand_dict_nond3ploy(output_file,
+                                                           commod, False)
+
+    name = 'eg01-eg24-flatpower-nond3ploy_' + commod
+    plotter.plot_demand_supply_nond3ploy(all_dict[commod],
+                                         agent_entry_dict[commod],
+                                         commod, name, False, True, 1)

--- a/input/eg01-eg24/plot_flatpower_nond3ploy.py
+++ b/input/eg01-eg24/plot_flatpower_nond3ploy.py
@@ -18,9 +18,9 @@ import collections
 direc = os.listdir('./')
 
 # Delete previously generated files
-#hit_list = glob.glob('*.png') + glob.glob('*.csv') + glob.glob('*.txt')
-#for file in hit_list:
-#    os.remove(file)
+# hit_list = glob.glob('*.png') + glob.glob('*.csv') + glob.glob('*.txt')
+# for file in hit_list:
+#     os.remove(file)
 
 ENV = dict(os.environ)
 ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')

--- a/input/eg01-eg24/plot_flatpower_nond3ploy.py
+++ b/input/eg01-eg24/plot_flatpower_nond3ploy.py
@@ -21,7 +21,7 @@ direc = os.listdir('./')
 # hit_list = glob.glob('*.png') + glob.glob('*.csv') + glob.glob('*.txt')
 # for file in hit_list:
 #     os.remove(file)
-
+  
 ENV = dict(os.environ)
 ENV['PYTHONPATH'] = ".:" + ENV.get('PYTHONPATH', '')
 


### PR DESCRIPTION
This PR addresses https://github.com/arfc/transition-scenarios/issues/92 and https://github.com/arfc/transition-scenarios/issues/93.
This PR contains scripts that produce .xml and .sqlite files for eg01-eg23 and eg01-eg24 for a case where the power demand is flat and 60 GW. The PR also contains scripts to produce plots for those cases.

The files contained in the PR are:

- flatpower_d3ploy.py

produces .xml and .sqlite for all the prediction methods.

https://github.com/robfairh/transition-scenarios/blob/experimental4/input/eg01-eg23/flatpower_d3ploy.py
&
https://github.com/robfairh/transition-scenarios/blob/experimental4/input/eg01-eg24/flatpower_d3ploy.py

- flatpower_d3ploy_plot.py

produces .csv and .png files for power. It makes 3 plots to compare the different prediction methods. One for NO, one for DO, and one for SO.

https://github.com/robfairh/transition-scenarios/blob/experimental4/input/eg01-eg23/flatpower_d3ploy_plot.py
&
https://github.com/robfairh/transition-scenarios/blob/experimental4/input/eg01-eg24/flatpower_d3ploy_plot.py

- plot_d3ploy.py

produces .csv and .png files for all the defined commodities. It does it for only one .sqlite file. It does not compare between prediction methods.

https://github.com/robfairh/transition-scenarios/blob/experimental4/input/eg01-eg23/plot_d3ploy.py
&
https://github.com/robfairh/transition-scenarios/blob/experimental4/input/eg01-eg24/plot_d3ploy.py

- plot_diff_buff_sizes.py

produces a .png file comparing cumulative undersupply for different buffer sizes. It can be changed to forward steps.

https://github.com/robfairh/transition-scenarios/blob/experimental4/input/eg01-eg23/plot_diff_buff_sizes.py

- plot_flatpower_nond3ploy.py: (This should have been uploaded in a previous PR to address https://github.com/arfc/transition-scenarios/issues/97 and https://github.com/arfc/transition-scenarios/issues/96)

produces .png files with plots of demand and supply for the case that does not use d3ploy.

https://github.com/robfairh/transition-scenarios/blob/experimental4/input/eg01-eg23/plot_flatpower_nond3ploy.py
&
https://github.com/robfairh/transition-scenarios/blob/experimental4/input/eg01-eg24/plot_flatpower_nond3ploy.py