### PR TITLE
Move import of functions to test

### DIFF
--- a/scripts/tests/test_transition_metrics.py
+++ b/scripts/tests/test_transition_metrics.py
@@ -1,4 +1,3 @@
-import transition_metrics as tm
 import unittest
 import cymetric
 import numpy as np
@@ -8,7 +7,9 @@ from uuid import UUID
 from pandas._testing import assert_series_equal
 from pandas._testing import assert_frame_equal
 import sys
+
 sys.path.insert(0, '../')
+import transition_metrics as tm
 
 
 class Test_static_info(unittest.TestCase):


### PR DESCRIPTION
Somehow a change to import the module `transition_metrics` to test the functions wasn't saved. The change added here moves `import transition_metrics as tm` to after the change to the system path so the module can be found. This change allows the module to be found, and the tests pass. 
