### PR TITLE
Update add_receiver_prototype function

### DIFF
--- a/scripts/tests/test_transition_metrics.py
+++ b/scripts/tests/test_transition_metrics.py
@@ -335,56 +335,56 @@ class Test_static_info(unittest.TestCase):
     def test_add_receiver_prototype(self):
         exp = pd.DataFrame(
             data={
-                'Time': [
-                    1,
-                    1,
-                    1,
-                    2],
                 'SimId': [
                     UUID('17b1bed5-0981-4682-a9be-05e60e7257cc'),
                     UUID('17b1bed5-0981-4682-a9be-05e60e7257cc'),
                     UUID('17b1bed5-0981-4682-a9be-05e60e7257cc'),
                     UUID('17b1bed5-0981-4682-a9be-05e60e7257cc')],
                 'TransactionId': [
-                    0.0,
-                    1.0,
-                    2.0,
-                    3.0],
-                'ResourceId': [
-                    10.0,
-                    12.0,
-                    14.0,
-                    26.0],
-                'ObjId': [
-                    9.0,
-                    10.0,
-                    11.0,
-                    21.0],
+                    0,
+                    1,
+                    2,
+                    3],
                 'SenderId': [
-                    21.0,
-                    21.0,
-                    21.0,
-                    21.0],
+                    21,
+                    21,
+                    21,
+                    21],
                 'ReceiverId': [
-                    24.0,
-                    24.0,
-                    24.0,
-                    24.0],
+                    24,
+                    24,
+                    24,
+                    24],
+                'ResourceId': [
+                    10,
+                    12,
+                    14,
+                    26],
                 'Commodity': [
                     'fresh_uox',
                     'fresh_uox',
                     'fresh_uox',
                     'fresh_uox'],
-                'Units': [
-                    'kg',
-                    'kg',
-                    'kg',
-                    'kg'],
+                'Time': [
+                    1,
+                    1,
+                    1,
+                    2],
+                'ObjId': [
+                    9,
+                    10,
+                    11,
+                    21],
                 'Quantity': [
                     33000.0,
                     33000.0,
                     33000.0,
                     33000.0],
+                'Units': [
+                    'kg',
+                    'kg',
+                    'kg',
+                    'kg'],
                 'Prototype': [
                     'Reactor_type1',
                     'Reactor_type1',

--- a/scripts/tests/test_transition_metrics.py
+++ b/scripts/tests/test_transition_metrics.py
@@ -167,8 +167,9 @@ class Test_static_info(unittest.TestCase):
         })
         nonlwr = ['Repository', 'FuelSupply', 'United States',
                   'FuelCycle', 'UNITED_STATES_OF_AMERICA']
-        obs = tm.get_prototype_totals(self.output_file1, nonlwr, ['Reactor_type1',
-                                                                  'Reactor_type2'])
+        obs = tm.get_prototype_totals(
+            self.output_file1, nonlwr, [
+                'Reactor_type1', 'Reactor_type2'])
         assert_frame_equal(
             exp, obs[['advrx_enter', 'advrx_total']][0:4], check_names=False)
 
@@ -187,8 +188,9 @@ class Test_static_info(unittest.TestCase):
         })
         nonlwr = ['Repository', 'FuelSupply', 'United States',
                   'FuelCycle', 'UNITED_STATES_OF_AMERICA']
-        obs = tm.get_prototype_totals(self.output_file2, nonlwr, ['Reactor_type1',
-                                                                  'Reactor_type2'])
+        obs = tm.get_prototype_totals(
+            self.output_file2, nonlwr, [
+                'Reactor_type1', 'Reactor_type2'])
         assert_frame_equal(
             exp, obs[['advrx_enter', 'advrx_total']][0:4], check_names=False)
 

--- a/scripts/transition_metrics.py
+++ b/scripts/transition_metrics.py
@@ -175,7 +175,7 @@ def get_prototype_totals(db_file, non_lwr_prototypes, prototypes):
         if prototype in prototypes_df.columns:
             prototypes_df = prototypes_df.rename(
                 columns={prototype: prototype + '_enter'})
-            prototypes_df[prototype + 
+            prototypes_df[prototype +
                           '_exit'] = np.zeros(len(prototypes_df[prototype + '_enter']))
         prototypes_df[prototype +
                       '_total'] = (prototypes_df[prototype +

--- a/scripts/transition_metrics.py
+++ b/scripts/transition_metrics.py
@@ -175,8 +175,8 @@ def get_prototype_totals(db_file, non_lwr_prototypes, prototypes):
         if prototype in prototypes_df.columns:
             prototypes_df = prototypes_df.rename(
                 columns={prototype: prototype + '_enter'})
-            prototypes_df[prototype +
-                          '_exit'] = np.zeros(len(prototypes_df[prototype + '_enter']))
+            prototypes_df[prototype + \
+                '_exit'] = np.zeros(len(prototypes_df[prototype + '_enter']))
         prototypes_df[prototype +
                       '_total'] = (prototypes_df[prototype +
                                                  '_enter'] +
@@ -342,10 +342,12 @@ def add_receiver_prototype(db_file):
     agents = agents.rename(columns={'AgentId': 'ReceiverId'})
     resources = evaler.eval('Resources')
     resources = resources[['SimId', 'ResourceId', 'ObjId', 'TimeCreated',
-                   'Quantity', 'Units']]
+                           'Quantity', 'Units']]
     resources = resources.rename(columns={'TimeCreated': 'Time'})
     transactions = evaler.eval('Transactions')
-    trans_resources = pd.merge(transactions, resources, on=['SimId', 'Time', 'ResourceId'], how='inner')
+    trans_resources = pd.merge(
+        transactions, resources, on=[
+            'SimId', 'Time', 'ResourceId'], how='inner')
     receiver_prototype = pd.merge(
         trans_resources, agents[['SimId', 'ReceiverId', 'Prototype']], on=[
             'SimId', 'ReceiverId']).sort_values(by=['Time', 'TransactionId']).reset_index(drop=True)

--- a/scripts/transition_metrics.py
+++ b/scripts/transition_metrics.py
@@ -175,8 +175,8 @@ def get_prototype_totals(db_file, non_lwr_prototypes, prototypes):
         if prototype in prototypes_df.columns:
             prototypes_df = prototypes_df.rename(
                 columns={prototype: prototype + '_enter'})
-            prototypes_df[prototype + \
-                '_exit'] = np.zeros(len(prototypes_df[prototype + '_enter']))
+            prototypes_df[prototype + 
+                          '_exit'] = np.zeros(len(prototypes_df[prototype + '_enter']))
         prototypes_df[prototype +
                       '_total'] = (prototypes_df[prototype +
                                                  '_enter'] +

--- a/scripts/transition_metrics.py
+++ b/scripts/transition_metrics.py
@@ -337,12 +337,17 @@ def add_receiver_prototype(db_file):
         contains all of the transactions with the prototype name of the
         receiver included
     '''
-    transactions = get_transactions(db_file)
     evaler = get_metrics(db_file)
     agents = evaler.eval('Agents')
     agents = agents.rename(columns={'AgentId': 'ReceiverId'})
+    resources = evaler.eval('Resources')
+    resources = resources[['SimId', 'ResourceId', 'ObjId', 'TimeCreated',
+                   'Quantity', 'Units']]
+    resources = resources.rename(columns={'TimeCreated': 'Time'})
+    transactions = evaler.eval('Transactions')
+    trans_resources = pd.merge(transactions, resources, on=['SimId', 'Time', 'ResourceId'], how='inner')
     receiver_prototype = pd.merge(
-        transactions, agents[['SimId', 'ReceiverId', 'Prototype']], on=[
+        trans_resources, agents[['SimId', 'ReceiverId', 'Prototype']], on=[
             'SimId', 'ReceiverId']).sort_values(by=['Time', 'TransactionId']).reset_index(drop=True)
     return receiver_prototype
 


### PR DESCRIPTION
This PR updates the `add_receiver_prototype` function in `scripts/transition_metrics.py`. This change avoids the creation and use of the `Materials` metric in cymetric, because this metric required more memory than what is available on my machine. 

The corresponding test in `scripts/tests/test_transition_metrics.py` has been updated for the change in datatype and column ordering in the resulting dataframe. The test passes. 
 