### PR TITLE
Update to commodity_to_LWR function

### DIFF
--- a/scripts/tests/test_transition_metrics.py
+++ b/scripts/tests/test_transition_metrics.py
@@ -476,7 +476,7 @@ class Test_static_info(unittest.TestCase):
         obs = tm.commodity_to_LWR(
             transactions_df,
             'fresh_uox',
-            'Reactor_type2')
+            ['Reactor_type2'])
         assert_frame_equal(exp, obs[0:4])
 
     def test_commodity_to_LWR2(self):
@@ -493,7 +493,7 @@ class Test_static_info(unittest.TestCase):
                     0.0, 99000.0, 42900.0, 13200.0], 'Year': [
                     1965.00, 1965.08, 1965.17, 1965.25]})
         transactions_df = tm.add_receiver_prototype(self.output_file1)
-        obs = tm.commodity_to_LWR(transactions_df, 'fresh_uox', 'Repository')
+        obs = tm.commodity_to_LWR(transactions_df, 'fresh_uox', ['Repository'])
         assert_frame_equal(exp, obs[0:4])
 
     def test_commodity_to_LWR3(self):
@@ -509,7 +509,26 @@ class Test_static_info(unittest.TestCase):
                     0.0, 0.0, 0.0, 0.0], 'Year': [
                     1965.00, 1965.08, 1965.17, 1965.25]})
         transactions_df = tm.add_receiver_prototype(self.output_file1)
-        obs = tm.commodity_to_LWR(transactions_df, 'u_ore', 'Reactor_type2')
+        obs = tm.commodity_to_LWR(transactions_df, 'u_ore', ['Reactor_type2'])
+        assert_frame_equal(exp, obs[0:4])
+
+    def test_commodity_to_LWR4(self):
+        ''' 
+        This function tests the transactions returned when there are 
+        multiple prototypes specified in the inputs (Reactor_type2,
+        Repository), given as a list. The commodity specified is 
+        present in the simulation, and sent to one of the specified 
+        prototypes (Reactor_type2), but not the other (Repository).
+        '''
+        exp = pd.DataFrame(
+            data={
+                'Time': [
+                    0, 1, 2, 3], 'Quantity': [
+                    0.0, 99000.0, 33000.0, 0.0], 'Year': [
+                    1965.00, 1965.08, 1965.17, 1965.25]})
+        transactions_df = tm.add_receiver_prototype(self.output_file1)
+        obs = tm.commodity_to_LWR(transactions_df, 'fresh_uox',
+         ['Reactor_type2', 'Repository'])
         assert_frame_equal(exp, obs[0:4])
 
     def test_get_annual_electricity(self):

--- a/scripts/tests/test_transition_metrics.py
+++ b/scripts/tests/test_transition_metrics.py
@@ -11,7 +11,6 @@ import sys
 sys.path.insert(0, '../')
 import transition_metrics as tm
 
-
 class Test_static_info(unittest.TestCase):
     def setUp(self):
         '''
@@ -513,11 +512,11 @@ class Test_static_info(unittest.TestCase):
         assert_frame_equal(exp, obs[0:4])
 
     def test_commodity_to_LWR4(self):
-        ''' 
-        This function tests the transactions returned when there are 
+        '''
+        This function tests the transactions returned when there are
         multiple prototypes specified in the inputs (Reactor_type2,
-        Repository), given as a list. The commodity specified is 
-        present in the simulation, and sent to one of the specified 
+        Repository), given as a list. The commodity specified is
+        present in the simulation, and sent to one of the specified
         prototypes (Reactor_type2), but not the other (Repository).
         '''
         exp = pd.DataFrame(
@@ -528,7 +527,7 @@ class Test_static_info(unittest.TestCase):
                     1965.00, 1965.08, 1965.17, 1965.25]})
         transactions_df = tm.add_receiver_prototype(self.output_file1)
         obs = tm.commodity_to_LWR(transactions_df, 'fresh_uox',
-         ['Reactor_type2', 'Repository'])
+                                  ['Reactor_type2', 'Repository'])
         assert_frame_equal(exp, obs[0:4])
 
     def test_get_annual_electricity(self):

--- a/scripts/transition_metrics.py
+++ b/scripts/transition_metrics.py
@@ -403,7 +403,7 @@ def commodity_to_LWR(transactions_df, commodity, prototype):
     commodity: str
         commodity of interest
     prototype: list of str
-        name of non-LWR reactor prototype in the simulation
+        name(s) of non-LWR reactor prototype(s) in the simulation
 
     Output:
     -------

--- a/scripts/transition_metrics.py
+++ b/scripts/transition_metrics.py
@@ -402,7 +402,7 @@ def commodity_to_LWR(transactions_df, commodity, prototype):
         dataframe
     commodity: str
         commodity of interest
-    prototype: str
+    prototype: list of str
         name of non-LWR reactor prototype in the simulation
 
     Output:
@@ -413,8 +413,8 @@ def commodity_to_LWR(transactions_df, commodity, prototype):
     '''
     prototype_transactions = find_commodity_transactions(
         transactions_df, commodity)
-    prototype_transactions = prototype_transactions.loc[
-        prototype_transactions['Prototype'] != prototype]
+    prototype_transactions = prototype_transactions[
+        ~prototype_transactions['Prototype'].isin(prototype)]
     prototype_transactions = sum_and_add_missing_time(prototype_transactions)
     prototype_transactions = add_year(prototype_transactions)
     return prototype_transactions


### PR DESCRIPTION
This PR includes an update to the `commodity_to_LWR` function of `scripts/transition_metrics.py` to accept a list of strings (the prototype names) instead of a single string. This is necessary to add flexibility to the function for when there are multiple prototype names that are not LWRs in the simulations. The corresponding tests have been updated, and a new test was written to specifically test this function with multiple prototype names are provided. 