### PR TITLE
Update advanced reactor deployment scheme

### DIFF
--- a/scripts/create_AR_DeployInst.py
+++ b/scripts/create_AR_DeployInst.py
@@ -87,7 +87,8 @@ def get_powers(path):
     Read through each of the xml files in a given path to get the power
     output of each reactor facility. Getting this information from these
     files accounts for any capacity factors, which are not captured in
-    the PRIS database.
+    the PRIS database. Assumes that all xml files in the specified 
+    directory are for a Cycamore reactor. 
 
     Parameters:
     -----------
@@ -104,7 +105,10 @@ def get_powers(path):
     rx_power = {}
     for filename in os.listdir(path):
         file = os.path.join(path, filename)
+        if file[-4:] != ".xml":
+            continue
         rx_info = convert_xml_to_dict(file)
+
         rx_power.update(
             {filename[:-4]: rx_info['facility']['config']['Reactor']['power_cap']})
     return rx_power
@@ -315,6 +319,8 @@ def deploy_with_share(reactor_prototypes, shares, power, reactor):
     num_rxs = math.ceil(
             required_share /
             reactor_prototypes[reactor][0])
+    if num_rxs <=0:
+        num_rxs = 0
     
     return num_rxs
 

--- a/scripts/create_AR_DeployInst.py
+++ b/scripts/create_AR_DeployInst.py
@@ -221,6 +221,39 @@ def determine_deployment_order(reactor_prototypes):
         prototypes.pop(max_power_prototype, None)
     return reactor_order
 
+def update_di(di, prototype, num_rxs, build_time, lifetime):
+    '''
+    Update a dictionary of a DeployInst
+
+    Parameters:
+    -----------
+    di: dictionary 
+        dictionary defining the DeployInst, the top-level key 
+        is 'DeployInst', the next level keys are 'prototypes',
+        'n_build', 'lifetimes', and 'build_times'. Each of the 
+        second level keys have a nested dictionary of 
+        'val':list
+    prototype: str 
+        name of prototype to be deployed
+    num_rxs: int
+        number of prototypes to be deployed 
+    build_time: int 
+        time step to deploy the prototype
+    lifetime: int 
+        lifetime of the prototype
+    
+    Returns:
+    --------
+    di: dictionary 
+        updated dictionary to define the DeployInst
+    '''
+    di['DeployInst']['prototypes']['val'].append(prototype)
+    di['DeployInst']['n_build']['val'].append(num_rxs)
+    di['DeployInst']['build_times']['val'].append(build_time)
+    di['DeployInst']['lifetimes']['val'].append(lifetime)
+    
+    return di
+
 
 def determine_deployment_schedule(
         power_gap,
@@ -275,12 +308,7 @@ def determine_deployment_schedule(
                 power_gap[index:index + reactor_prototypes[prototype]
                           [1]] - reactor_prototypes[prototype][0] * num_rxs
             value = value - reactor_prototypes[prototype][0] * num_rxs
-            deploy_schedule['DeployInst']['prototypes']['val'].append(
-                prototype)
-            deploy_schedule['DeployInst']['n_build']['val'].append(num_rxs)
-            deploy_schedule['DeployInst']['build_times']['val'].append(index)
-            deploy_schedule['DeployInst']['lifetimes']['val'].append(
-                reactor_prototypes[prototype][1])
+            deploy_schedule = update_di(deploy_schedule, reactor, num_rxs, index, reactor_prototypes[reactor][1])
         for reactor in reactors:
             if reactor == reactors[-1]:
                 # for the last reactor round up to ensure gap is fully met, even if
@@ -294,11 +322,7 @@ def determine_deployment_schedule(
                 power_gap[index:index + reactor_prototypes[reactor]
                           [1]] - reactor_prototypes[reactor][0] * num_rxs
             value = value - reactor_prototypes[reactor][0] * num_rxs
-            deploy_schedule['DeployInst']['prototypes']['val'].append(reactor)
-            deploy_schedule['DeployInst']['n_build']['val'].append(num_rxs)
-            deploy_schedule['DeployInst']['build_times']['val'].append(index)
-            deploy_schedule['DeployInst']['lifetimes']['val'].append(
-                reactor_prototypes[reactor][1])
+            deploy_schedule = update_di(deploy_schedule, reactor, num_rxs, index, reactor_prototypes[reactor][1])
 
     return deploy_schedule
 

--- a/scripts/create_AR_DeployInst.py
+++ b/scripts/create_AR_DeployInst.py
@@ -401,8 +401,7 @@ def determine_deployment_schedule(
                                  e == previous_time]
                 for item in previous_index:
                     if deploy_schedule['DeployInst']['prototypes']['val'][item] == reactor:
-                        print('redeploy', reactor, value)
-                        num_rxs = deploy_schedule['DeployInst']['n_build']['val'][item]
+                        num_rxs = math.ceil(value/ reactor_prototypes[reactor][0])
                         power_gap, value = update_power_demand(power_gap, index, value, num_rxs, reactor_prototypes, reactor)
                         deploy_schedule = update_di(deploy_schedule, reactor, num_rxs, index,
                                                            reactor_prototypes[reactor][1])

--- a/scripts/create_AR_DeployInst.py
+++ b/scripts/create_AR_DeployInst.py
@@ -270,7 +270,7 @@ def update_power_demand(
         prototype):
     '''
     Subtracts power from the total demand to be filled
-    based on the number of reactors to be deployed.
+    based on the number of reactors to be deployed
 
     Parameters:
     power_gap: list or array
@@ -282,7 +282,7 @@ def update_power_demand(
     num_rxs: int
         number of reactors of a given prototype to deploy
     reactor_prototypes: dict
-        Keys are the names of the prototypes, the values are a
+        keys are the names of the prototypes, the values are a
         tuple of the power output and lifetime of the
         prototype
     prototype: str
@@ -311,11 +311,11 @@ def deploy_with_share(reactor_prototypes, shares, power, reactor):
     Parameters:
     -----------
     reactor_prototypes: dict
-        information about prototypes, {name (str):(power(float), 
-        lifetime(int))}
+        information about prototypes, 
+        {name(str):(power(float),lifetime(int))}
     shares: dict
         contains information about build share for specified
-        prototypes, {name (Str): build share (int)}
+        prototypes, {name(str):build share(int)}
     power: float
         amount of power that needs to be deployed at a given time step.
     prototype: str
@@ -325,7 +325,7 @@ def deploy_with_share(reactor_prototypes, shares, power, reactor):
     --------
     num_rxs: int
         number of the specified prototype to be deployed at a given time
-        step.
+        step
     '''
     required_share = power * (shares[reactor] / 100)
     num_rxs = math.ceil(
@@ -337,7 +337,7 @@ def deploy_with_share(reactor_prototypes, shares, power, reactor):
 
 def deploy_without_share(prototype, reactors, reactor_prototypes, power):
     '''
-    Deploy reactors when a build share isn't supplied for the prototype.
+    Deploy reactors when a build share isn't supplied for the prototype
 
     Parameters:
     -----------
@@ -347,16 +347,16 @@ def deploy_without_share(prototype, reactors, reactor_prototypes, power):
         list of all prototypes that don't have a specified build share,
         the order of prototypes is in descending order of power output
     reactor_prototypes: dict
-        information about prototypes, {name (str):(power(float), 
-        lifetime(int))}
+        information about prototypes, 
+        {name(str):(power(float),lifetime(int))}
     power: float
-        amount of power that needs to be deployed at a given time step.
+        amount of power that needs to be deployed at a given time step
 
     Returns:
     --------
     num_rxs: int
         number of the specified prototype to be deployed at a given time
-        step.
+        step
     '''
     if prototype == reactors[-1]:
         num_rxs = math.ceil(power / reactor_prototypes[prototype][0])
@@ -387,7 +387,7 @@ def determine_deployment_schedule(
         a tuple of the power output and lifetime (ints)
     shares: dict
         contains information about build share for specified
-        prototypes, {name (Str): build share (int)}
+        prototypes, {name(str): build share(int)}
 
     Returns:
     --------
@@ -539,7 +539,7 @@ def write_AR_deployinst(
         demand_eq,
         shares=None):
     ''''
-    Creates the DeployInst for deployment of advanced reactors.
+    Creates the DeployInst for the deployment of advanced reactors
 
     Parameters:
     -----------
@@ -552,13 +552,13 @@ def write_AR_deployinst(
         number of time steps in the simulation
     reactor_prototypes: dict
         dictionary of information about prototypes in the form
-        {name(str): (power(int), lifetime(int))}
+        {name(str):(power(int),lifetime(int))}
     demand_eq: array
         energy demand at each time step in the simulation, length
         must match the value of duration
     shares: dict
         contains information about build share for specified
-        prototypes, {name (Str): build share (int)}
+        prototypes, {name(str):build share(int)}
 
 
     Returns:

--- a/scripts/tests/test_create_AR_DeployInst.py
+++ b/scripts/tests/test_create_AR_DeployInst.py
@@ -199,7 +199,7 @@ class Test_static_info(unittest.TestCase):
     def test_update_di(self):
         '''
         Add the deployment of 2 Type2 reactors at timestep 40 with a
-        lifetime of 720 timesteps.
+        lifetime of 720 timesteps
         '''
         exp = {
             'DeployInst': {
@@ -284,7 +284,7 @@ class Test_static_info(unittest.TestCase):
     def test_determine_deployment_schedule1(self):
         '''
         Tests for a constant power demand of 440 MW for 10 time steps and
-        no build share specified.
+        no build share specified
         '''
         exp = {
             'DeployInst': {
@@ -308,9 +308,8 @@ class Test_static_info(unittest.TestCase):
         '''
         Tests with a defined prototype and build share (non-default values),
         defined as 50% for Type2 reactors.
-        A constant power demand of 595 MW for 10 time steps, which allows
-        for testing of a different number of the Type 2 reactor to be
-        redeployed.
+        A constant power demand of 595 MW for 10 time steps, which tests
+        for a different number of the Type 2 reactors under redeployed.
         '''
         exp = {
             'DeployInst': {


### PR DESCRIPTION
I have updated the functions in `scripts/create_AR_DeployInst.py` to redeploy advanced reactors on a 1:1 basis. This is done by looking at the defined deployments at timestep `current-lifetime of reactor`. Then the number of reactors to redeploy is calculated by rounding up on the demand of energy at the current timestep divided by the energy output of the reactor in question. It is not a direct replacement of the same number of reactors to reduce any oversupply of power that may be caused. 

Example:
4 of Type1 reactors are deployed at time 3, with a lifetime of 5 timesteps. They supply 100 MW for a total power supply of 500 MW against a demand of 480 MWe. 

At timestep 8, a total of 410 MW are already deployed so only 3 Type1 reactors need to be deployed to meet the demand of 480 MW. 

I have updated the tests for this module (`scripts/tests/test_create_AR_DeployInst.py`), and all tests pass. 