### PR TITLE
Correction to deployment scheme

### DIFF
--- a/scripts/create_AR_DeployInst.py
+++ b/scripts/create_AR_DeployInst.py
@@ -298,9 +298,9 @@ def update_power_demand(
         the deployment of a given number of a specified
         prototype
     '''
-    power_gap[index:index + reactor_prototypes[prototype]
-              [1]] -= reactor_prototypes[prototype][0] * num_reactors
-    power -= reactor_prototypes[prototype][0] * num_reactors
+    reactor = reactor_prototypes[prototype]
+    power_gap[index:index + reactor[1]] -= reactor[0] * num_reactors
+    power -= reactor[0] * num_reactors
     return power_gap, power
 
 

--- a/scripts/create_AR_DeployInst.py
+++ b/scripts/create_AR_DeployInst.py
@@ -96,23 +96,23 @@ def get_powers(path):
 
     Returns:
     --------
-    rx_power: dict
+    reactor_power: dict
         dictionary of reactor names and rated powers, the keys are the reactor
         names (strs), the values are their power outputs (ints). Any spaces
         in the keys are replaced with underscores.
     '''
-    rx_power = {}
+    reactor_power = {}
     for filename in os.listdir(path):
         file = os.path.join(path, filename)
         if file[-4:] != ".xml":
             continue
-        rx_info = convert_xml_to_dict(file)
+        reactor_info = convert_xml_to_dict(file)
 
-        rx_power.update(
-            {filename[:-4]: rx_info['facility']['config']['Reactor']['power_cap']
+        reactor_power.update(
+            {filename[:-4]: reactor_info['facility']['config']['Reactor']['power_cap']
              }
         )
-    return rx_power
+    return reactor_power
 
 
 def get_lifetime(path, name):

--- a/scripts/create_AR_DeployInst.py
+++ b/scripts/create_AR_DeployInst.py
@@ -419,6 +419,8 @@ def determine_deployment_schedule(
                     if deploy_schedule['DeployInst']['prototypes']['val'][item] == reactor:
                         num_rxs = math.ceil(
                             value / reactor_prototypes[reactor][0])
+                        if num_rxs <= 0:
+                            continue
                         power_gap, value = update_power_demand(power_gap,
                                                                index,
                                                                value,

--- a/scripts/create_AR_DeployInst.py
+++ b/scripts/create_AR_DeployInst.py
@@ -417,10 +417,7 @@ def determine_deployment_schedule(
                         e == previous_time]
                 for item in previous_index:
                     if deploy_schedule['DeployInst']['prototypes']['val'][item] == reactor:
-                        num_rxs = math.ceil(
-                            value / reactor_prototypes[reactor][0])
-                        if num_rxs <= 0:
-                            continue
+                        num_rxs = deploy_schedule['DeployInst']['n_build']['val'][item]
                         power_gap, value = update_power_demand(power_gap,
                                                                index,
                                                                value,

--- a/scripts/tests/test_create_AR_DeployInst.py
+++ b/scripts/tests/test_create_AR_DeployInst.py
@@ -99,6 +99,16 @@ class Test_static_info(unittest.TestCase):
                 80, 3), 'Type2': (
                 25, 5), 'Type3': (
                 50, 10)}
+        self.deploy_schedule = {'DeployInst':{
+                            'prototypes':{
+                                'val':['Type1']},
+                            'n_build':{
+                                'val':[2]},
+                            'build_times':{
+                                'val':[0]},
+                            'lifetimes':{
+                                'val':[3]}
+                            }}
 
     def test_convert_xml_to_dict(self):
         '''
@@ -351,20 +361,11 @@ class Test_static_info(unittest.TestCase):
         Test when the calculated number is equal to the previous deployment
         '''
         exp = 2
-        deploy_schedule = {'DeployInst':{
-                            'prototypes':{
-                                'val':['Type1']},
-                            'n_build':{
-                                'val':[2]},
-                            'build_times':{
-                                'val':[0]},
-                            'lifetimes':{
-                                'val':[3]}
-                            }}
+        
         obs = di.redeploy_reactors(150, 
                                    'Type1', 
                                    self.reactor_prototypes,
-                                   deploy_schedule,
+                                   self.deploy_schedule,
                                    0)
         assert exp == obs
 
@@ -373,20 +374,10 @@ class Test_static_info(unittest.TestCase):
         Test when the calculated number is negative
         '''
         exp = 0
-        deploy_schedule = {'DeployInst':{
-                            'prototypes':{
-                                'val':['Type1']},
-                            'n_build':{
-                                'val':[2]},
-                            'build_times':{
-                                'val':[0]},
-                            'lifetimes':{
-                                'val':[3]}
-                            }}
         obs = di.redeploy_reactors(-150, 
                                    'Type1', 
                                    self.reactor_prototypes,
-                                   deploy_schedule,
+                                   self.deploy_schedule,
                                    0)
         assert exp == obs
         

--- a/scripts/tests/test_create_AR_DeployInst.py
+++ b/scripts/tests/test_create_AR_DeployInst.py
@@ -292,7 +292,7 @@ class Test_static_info(unittest.TestCase):
                                       self.reactor_prototypes, 220)
         assert exp == obs
 
-    def test_deploy_without_share2(self):
+    def test_deploy_without_share3(self):
         '''
         Test when the calculated number is negative'''
         exp = 0
@@ -425,9 +425,9 @@ class Test_static_info(unittest.TestCase):
             'DeployInst': {
                 'prototypes': {
                     'val': [
-                        'Type2', 
                         'Type1', 
-                        'Type3', 
+                        'Type3',
+                        'Type2', 
                         'Type1', 
                         'Type2', 
                         'Type1', 
@@ -436,9 +436,9 @@ class Test_static_info(unittest.TestCase):
                     'val': [
                         0, 0, 0, 3, 5, 6, 9]},
                 'n_build': {'val': [
-                    12, 3, 2, 3, 11, 3, 3]},
+                    3, 2, 12, 3, 11, 3, 3]},
                 'lifetimes': {'val': [
-                    5, 3, 10, 3, 5, 3, 3]}}}
+                    3, 10, 5, 3, 5, 3, 3]}}}
         gap = np.repeat(595, 10)
         obs = di.determine_deployment_schedule(gap, self.reactor_prototypes,
                                                {'Type2': 50})
@@ -496,8 +496,8 @@ class Test_static_info(unittest.TestCase):
                             'Type1',
                             'Type1',
                             'Type3',
-                            'Type2'
-                    ]},
+                            'Type2',
+                            ]},
                 'build_times': {
                     'val': [
                         0, 0, 0, 3, 5, 6, 9, 10, 10]},
@@ -505,7 +505,7 @@ class Test_static_info(unittest.TestCase):
                     6, 1, 2, 6, 1, 6, 3, 1, 1]},
                 'lifetimes': {'val': [
                     3, 10, 5, 3, 5, 3, 3, 10, 5]}}}
-        gap = [575, 575, 575, 575, 540, 540, 540, 540, 300, 300, 300]
+        gap = np.array([556, 556, 556, 556, 540, 540, 540, 540, 300, 300, 300])
         obs = di.determine_deployment_schedule(gap, self.reactor_prototypes)
         assert exp == obs
      
@@ -525,21 +525,24 @@ class Test_static_info(unittest.TestCase):
                             'Type2',
                             'Type1',
                             'Type2',
+                            'Type2',
                             'Type1',
                             'Type1',
+                            'Type3',
+                            'Type2',
                             'Type1',
-                            'Type1',
+                            'Type2',
                             'Type3',
                             'Type2'
                     ]},
                 'build_times': {
                     'val': [
-                        0, 0, 0, 3, 5, 6, 9, 10, 10, 10]},
+                        0, 0, 0, 3, 4, 5, 6, 8, 8, 8, 9, 9, 10, 10]},
                 'n_build': {'val': [
-                    6, 1, 2, 6, 3, 6, 6, 3, 2, 4]},
+                    6, 1, 2, 6, 1, 2, 6, 3, 1, 1, 6, 1, 1, 2]},
                 'lifetimes': {'val': [
-                    3, 10, 5, 3, 5, 5, 3, 3, 3, 10, 5]}}}
-        gap = [575, 575, 575, 575, 540, 540, 540, 540, 300, 300, 300]
+                    3, 10, 5, 3, 5, 5, 3, 3, 10, 5, 3, 5, 10, 5]}}}
+        gap = np.array([556, 556, 556, 556, 600, 600, 600, 600, 900, 900, 900])
         obs = di.determine_deployment_schedule(gap, self.reactor_prototypes)
         assert exp == obs
 
@@ -554,23 +557,23 @@ class Test_static_info(unittest.TestCase):
         exp = {
             'DeployInst': {
                 'prototypes': {
-                    'val': ['Type2',
-                            'Type1',
+                    'val': ['Type1',
                             'Type3',
+                            'Type2',
                             'Type1',
                             'Type2',
                             'Type1',
                             'Type3',
-                            'Type2'                    
-                    ]},
+                            'Type2',
+                            ]},
                 'build_times': {
                     'val': [
                         0, 0, 0, 3, 5, 6, 10, 10]},
                 'n_build': {'val': [
-                    12, 3, 1, 3, 10, 3, 1, 10]},
+                    3, 1, 12, 3, 10, 3, 1, 10]},
                 'lifetimes': {'val': [
-                    5, 3, 10, 3, 5, 3, 10, 5]}}}
-        gap = [575, 575, 575, 575, 540, 540, 540, 540, 300, 300, 300]
+                    3, 10, 5, 3, 5, 3, 10, 5]}}}
+        gap = np.array([556, 556, 556, 556, 540, 540, 540, 540, 300, 300, 300])
         obs = di.determine_deployment_schedule(gap,
                                                self.reactor_prototypes,
                                                {'Type2':50})
@@ -643,9 +646,9 @@ class Test_static_info(unittest.TestCase):
             'DeployInst': {
                 'prototypes': {
                     'val': [
-                        'Type2',
                         'Type1',
                         'Type3',
+                        'Type2',
                         'Type1',
                         'Type2',
                         'Type1',
@@ -654,9 +657,9 @@ class Test_static_info(unittest.TestCase):
                     'val': [
                         1200, 1200, 1200, 1203, 1205, 1206, 1209]},
                 'n_build': {'val': [
-                    9, 2, 2, 2, 8, 2, 2]},
+                    2, 2, 9, 2, 8, 2, 2]},
                 'lifetimes': {'val': [
-                    5, 3, 10, 3, 5, 3, 3]}}}
+                    3, 10, 5, 3, 5, 3, 3]}}}
 
         demand_eq = np.zeros(1210)
         demand_eq[1200:] = 440

--- a/scripts/tests/test_create_AR_DeployInst.py
+++ b/scripts/tests/test_create_AR_DeployInst.py
@@ -7,7 +7,6 @@ import sys
 sys.path.insert(0, '../')
 import create_AR_DeployInst as di
 
-
 class Test_static_info(unittest.TestCase):
     def setUp(self):
         '''
@@ -99,16 +98,16 @@ class Test_static_info(unittest.TestCase):
                 80, 3), 'Type2': (
                 25, 5), 'Type3': (
                 50, 10)}
-        self.deploy_schedule = {'DeployInst':{
-                            'prototypes':{
-                                'val':['Type1']},
-                            'n_build':{
-                                'val':[2]},
-                            'build_times':{
-                                'val':[0]},
-                            'lifetimes':{
-                                'val':[3]}
-                            }}
+        self.deploy_schedule = {'DeployInst': {
+            'prototypes': {
+                                'val': ['Type1']},
+            'n_build': {
+                'val': [2]},
+            'build_times': {
+                'val': [0]},
+            'lifetimes': {
+                'val': [3]}
+        }}
 
     def test_convert_xml_to_dict(self):
         '''
@@ -272,14 +271,14 @@ class Test_static_info(unittest.TestCase):
             self.reactor_prototypes, {
                 'Type2': 50, 'Type3': 5}, 200, 'Type2')
         assert exp == obs
-    
+
     def test_deploy_with_share3(self):
         '''
         Test when the calculated value is negative
         '''
         exp = 0
         obs = di.deploy_with_share(self.reactor_prototypes,
-                                   {'Type2':50},
+                                   {'Type2': 50},
                                    -100,
                                    'Type2')
         assert exp == obs
@@ -307,7 +306,7 @@ class Test_static_info(unittest.TestCase):
         Test when the calculated number is negative'''
         exp = 0
         obs = di.deploy_without_share('Type1',
-                                      ['Type1','Type3','Type2'],
+                                      ['Type1', 'Type3', 'Type2'],
                                       self.reactor_prototypes,
                                       -100)
         assert exp == obs
@@ -317,18 +316,18 @@ class Test_static_info(unittest.TestCase):
         Test when the calculated number is greater than the previous deployment
         '''
         exp = 2
-        deploy_schedule = {'DeployInst':{
-                            'prototypes':{
-                                'val':['Type1']},
-                            'n_build':{
-                                'val':[2]},
-                            'build_times':{
-                                'val':[0]},
-                            'lifetimes':{
-                                'val':[3]}
-                            }}
-        obs = di.redeploy_reactors(250, 
-                                   'Type1', 
+        deploy_schedule = {'DeployInst': {
+            'prototypes': {
+                'val': ['Type1']},
+            'n_build': {
+                'val': [2]},
+            'build_times': {
+                'val': [0]},
+            'lifetimes': {
+                'val': [3]}
+        }}
+        obs = di.redeploy_reactors(250,
+                                   'Type1',
                                    self.reactor_prototypes,
                                    deploy_schedule,
                                    0)
@@ -339,18 +338,18 @@ class Test_static_info(unittest.TestCase):
         Test when the calculated number is less than the previous deployment
         '''
         exp = 1
-        deploy_schedule = {'DeployInst':{
-                            'prototypes':{
-                                'val':['Type1']},
-                            'n_build':{
-                                'val':[2]},
-                            'build_times':{
-                                'val':[0]},
-                            'lifetimes':{
-                                'val':[3]}
-                            }}
-        obs = di.redeploy_reactors(80, 
-                                   'Type1', 
+        deploy_schedule = {'DeployInst': {
+            'prototypes': {
+                'val': ['Type1']},
+            'n_build': {
+                'val': [2]},
+            'build_times': {
+                'val': [0]},
+            'lifetimes': {
+                'val': [3]}
+        }}
+        obs = di.redeploy_reactors(80,
+                                   'Type1',
                                    self.reactor_prototypes,
                                    deploy_schedule,
                                    0)
@@ -361,9 +360,9 @@ class Test_static_info(unittest.TestCase):
         Test when the calculated number is equal to the previous deployment
         '''
         exp = 2
-        
-        obs = di.redeploy_reactors(150, 
-                                   'Type1', 
+
+        obs = di.redeploy_reactors(150,
+                                   'Type1',
                                    self.reactor_prototypes,
                                    self.deploy_schedule,
                                    0)
@@ -374,13 +373,12 @@ class Test_static_info(unittest.TestCase):
         Test when the calculated number is negative
         '''
         exp = 0
-        obs = di.redeploy_reactors(-150, 
-                                   'Type1', 
+        obs = di.redeploy_reactors(-150,
+                                   'Type1',
                                    self.reactor_prototypes,
                                    self.deploy_schedule,
                                    0)
         assert exp == obs
-        
 
     def test_determine_deployment_schedule1(self):
         '''
@@ -416,12 +414,12 @@ class Test_static_info(unittest.TestCase):
             'DeployInst': {
                 'prototypes': {
                     'val': [
-                        'Type1', 
+                        'Type1',
                         'Type3',
-                        'Type2', 
-                        'Type1', 
-                        'Type2', 
-                        'Type1', 
+                        'Type2',
+                        'Type1',
+                        'Type2',
+                        'Type1',
                         'Type1']},
                 'build_times': {
                     'val': [
@@ -438,10 +436,10 @@ class Test_static_info(unittest.TestCase):
     def test_determine_deployment_schedule3(self):
         '''
         Tests for a constant power demand of 575 MW for 11 time steps and
-        no build share specified. The longer time period of this test 
-        tests when multiple types of advanced reactors are decommissioned 
+        no build share specified. The longer time period of this test
+        tests when multiple types of advanced reactors are decommissioned
         at the same time, testing that the same number of each prototype
-        get redeployed. 
+        get redeployed.
         '''
         exp = {
             'DeployInst': {
@@ -467,10 +465,10 @@ class Test_static_info(unittest.TestCase):
         gap = np.repeat(556, 11)
         obs = di.determine_deployment_schedule(gap, self.reactor_prototypes)
         assert exp == obs
-        
+
     def test_determine_deployment_schedule4(self):
         '''
-        Tests for a variable power demand for 12 timesteps that 
+        Tests for a variable power demand for 12 timesteps that
         decreases with time, and no build share specified. This tests
         for a decreasing number of prototypes as the demand decreases.
         This tests the redeployment numbers when only one prototype
@@ -499,10 +497,10 @@ class Test_static_info(unittest.TestCase):
         gap = np.array([556, 556, 556, 556, 540, 540, 540, 540, 300, 300, 300])
         obs = di.determine_deployment_schedule(gap, self.reactor_prototypes)
         assert exp == obs
-     
+
     def test_determine_deployment_schedule5(self):
         '''
-        Tests for a variable power demand for 11 timesteps that 
+        Tests for a variable power demand for 11 timesteps that
         increases with time, and no build share specified. This tests
         for a decreasing number of prototypes as the demand decreases.
         This tests the redeployment numbers when only one prototype
@@ -525,7 +523,7 @@ class Test_static_info(unittest.TestCase):
                             'Type2',
                             'Type3',
                             'Type2'
-                    ]},
+                            ]},
                 'build_times': {
                     'val': [
                         0, 0, 0, 3, 4, 5, 6, 8, 8, 8, 9, 9, 10, 10]},
@@ -539,7 +537,7 @@ class Test_static_info(unittest.TestCase):
 
     def test_determine_deployment_schedule6(self):
         '''
-        Tests for a variable power demand for 12 timesteps that 
+        Tests for a variable power demand for 12 timesteps that
         decreases with time, and a build share specified. This tests
         for a decreasing number of prototypes as the demand decreases.
         This tests the redeployment numbers when only one prototype
@@ -567,7 +565,7 @@ class Test_static_info(unittest.TestCase):
         gap = np.array([556, 556, 556, 556, 540, 540, 540, 540, 300, 300, 300])
         obs = di.determine_deployment_schedule(gap,
                                                self.reactor_prototypes,
-                                               {'Type2':50})
+                                               {'Type2': 50})
         assert exp == obs
 
     def test_write_lwr_deployinst(self):
@@ -592,8 +590,8 @@ class Test_static_info(unittest.TestCase):
 
     def test_write_AR_deployinst1(self):
         '''
-        Test creation of AR DeployInst for a demand of 1000 MWe starting in 
-        2065, so the power from LWRs does not affect the advanced reactor 
+        Test creation of AR DeployInst for a demand of 1000 MWe starting in
+        2065, so the power from LWRs does not affect the advanced reactor
         deployment. A prototype with a defined buildshare is not specified.
         '''
         exp = {
@@ -628,9 +626,9 @@ class Test_static_info(unittest.TestCase):
 
     def test_write_AR_deployinst2(self):
         '''
-        Test creation of AR DeployInst for a demand of 1000 MWe starting in 
-        2065, so the power from LWRs does not affect the advanced reactor 
-        deployment. A prototype with a defined build share is specified: 50% 
+        Test creation of AR DeployInst for a demand of 1000 MWe starting in
+        2065, so the power from LWRs does not affect the advanced reactor
+        deployment. A prototype with a defined build share is specified: 50%
         Type2 build share.
         '''
         exp = {

--- a/scripts/tests/test_create_AR_DeployInst.py
+++ b/scripts/tests/test_create_AR_DeployInst.py
@@ -316,20 +316,10 @@ class Test_static_info(unittest.TestCase):
         Test when the calculated number is greater than the previous deployment
         '''
         exp = 2
-        deploy_schedule = {'DeployInst': {
-            'prototypes': {
-                'val': ['Type1']},
-            'n_build': {
-                'val': [2]},
-            'build_times': {
-                'val': [0]},
-            'lifetimes': {
-                'val': [3]}
-        }}
         obs = di.redeploy_reactors(250,
                                    'Type1',
                                    self.reactor_prototypes,
-                                   deploy_schedule,
+                                   self.deploy_schedule,
                                    0)
         assert exp == obs
 
@@ -338,20 +328,10 @@ class Test_static_info(unittest.TestCase):
         Test when the calculated number is less than the previous deployment
         '''
         exp = 1
-        deploy_schedule = {'DeployInst': {
-            'prototypes': {
-                'val': ['Type1']},
-            'n_build': {
-                'val': [2]},
-            'build_times': {
-                'val': [0]},
-            'lifetimes': {
-                'val': [3]}
-        }}
         obs = di.redeploy_reactors(80,
                                    'Type1',
                                    self.reactor_prototypes,
-                                   deploy_schedule,
+                                   self.deploy_schedule,
                                    0)
         assert exp == obs
 
@@ -360,7 +340,6 @@ class Test_static_info(unittest.TestCase):
         Test when the calculated number is equal to the previous deployment
         '''
         exp = 2
-
         obs = di.redeploy_reactors(150,
                                    'Type1',
                                    self.reactor_prototypes,


### PR DESCRIPTION
This PR fixes an issue observed after #141  was merged that was not caught in the test suite. With this PR the deployment scheme is as follows:
* when there is capacity to be installed from an increase in the demand or from decommissioning of facilities in another institution:
   - The prototypes are preferentially deployed based on power
   - The prototype with the largest capacity is deployed until an oversupply of energy would be created (round down on the number deployed)
   - The other prototypes are deployed in a similar manner until the smallest prototype is deployed
   - The smallest prototype is deployed until the demand is at least met (round up on the number deployed)
   - If there is a specified build share for one or more prototypes, then the prototypes with a specified build share are deployed first, and then the other prototypes are deployed based on the previous 4 points, with the prototypes with a specified build share removed from the deployment order (the list of prototypes in order of decreasing capacity)
* when there is capacity to be installed from the decommissioning of prototypes in this institution:
   - It is assumed first that the number of decommissioning prototypes are re-deployed (e.g. look at time step current minus the lifetime of the prototype in question)
   - If fewer prototypes can be deployed while still meeting the demand, such as in the case of a decrease in the demand, then the lesser number of prototypes are deployed. 

This PR fixes the issue of large variations in the number of prototypes re-deployed if multiple prototypes were decommissioned at the same time step. 

All tests currently pass. I encourage you to ensure that the test suite for these functions is comprehensive, as the error this fixes was not previously captured in the test suite. 