### PR TITLE
Remove get_transactions function

### DIFF
--- a/scripts/tests/test_transition_metrics.py
+++ b/scripts/tests/test_transition_metrics.py
@@ -215,7 +215,7 @@ class Test_static_info(unittest.TestCase):
                     'kg',
                     'kg',
                     'kg'],
-                'Prototype': [
+                'ReceiverPrototype': [
                     'Reactor_type1',
                     'Reactor_type1',
                     'Reactor_type1',
@@ -249,7 +249,7 @@ class Test_static_info(unittest.TestCase):
         Tests function when the queried non-LWR prototype is in the dataframe
         '''
         exp = pd.DataFrame(data={'Year': [1965, 1966], 'Energy': [0.10, 0.00]})
-        obs = tm.get_lwr_energy(self.output_file1, 'Reactor_type2')
+        obs = tm.get_lwr_energy(self.output_file1, ['Reactor_type2'])
         assert_frame_equal(exp, obs[0:2])
 
     def test_get_lwr_energy2(self):
@@ -258,5 +258,5 @@ class Test_static_info(unittest.TestCase):
         dataframe
         '''
         exp = pd.DataFrame(data={'Year': [1965, 1966], 'Energy': [0.12, 0.00]})
-        obs = tm.get_lwr_energy(self.output_file1, 'Reactor_type3')
+        obs = tm.get_lwr_energy(self.output_file1, ['Reactor_type3'])
         assert_frame_equal(exp, obs[0:2])

--- a/scripts/tests/test_transition_metrics.py
+++ b/scripts/tests/test_transition_metrics.py
@@ -162,52 +162,6 @@ class Test_static_info(unittest.TestCase):
         assert_frame_equal(
             exp, obs[['advrx_enter', 'advrx_total']][0:4], check_names=False)
 
-    def test_get_transactions(self):
-        exp = pd.DataFrame(
-            data={
-                'Time': [
-                    0,
-                    1,
-                    1],
-                'SimId': [
-                    0,
-                    UUID('17b1bed5-0981-4682-a9be-05e60e7257cc'),
-                    UUID('17b1bed5-0981-4682-a9be-05e60e7257cc')],
-                'TransactionId': [
-                    0.0,
-                    0.0,
-                    1.0],
-                'ResourceId': [
-                    0.0,
-                    10.0,
-                    12.0],
-                'ObjId': [
-                    0.0,
-                    9.0,
-                    10.0],
-                'SenderId': [
-                    0.0,
-                    21.0,
-                    21.0],
-                'ReceiverId': [
-                    0.0,
-                    24.0,
-                    24.0],
-                'Commodity': [
-                    0,
-                    'fresh_uox',
-                    'fresh_uox'],
-                'Units': [
-                    0,
-                    'kg',
-                    'kg'],
-                'Quantity': [
-                    0.0,
-                    33000.0,
-                    33000.0]})
-        obs = tm.get_transactions(self.output_file1)
-        assert_frame_equal(exp, obs[0:3])
-
     def test_add_receiver_prototype(self):
         exp = pd.DataFrame(
             data={

--- a/scripts/transition_metrics.py
+++ b/scripts/transition_metrics.py
@@ -160,32 +160,6 @@ def get_prototype_totals(db_file, non_lwr_prototypes, prototypes):
 
     return prototypes_df
 
-
-def get_transactions(db_file):
-    '''
-    Gets the TransactionQuantity metric from cymetric,
-    sorts by TimeCreated, and renames the TimeCreated
-    column
-
-    Parametrs:
-    ----------
-    db_file: str
-        relative path to database
-
-    Returns:
-    --------
-    transactions: DataFrame
-        transaction data with specified modifications
-    '''
-    evaler = get_metrics(db_file)
-    transactions = evaler.eval(
-        'TransactionQuantity').sort_values(by='TimeCreated')
-    transactions = transactions.rename(columns={'TimeCreated': 'Time'})
-    transactions = tools.add_missing_time_step(
-        transactions, evaler.eval('TimeList'))
-    return transactions
-
-
 def add_receiver_prototype(db_file):
     '''
     Creates dataframe of transactions information, and adds in


### PR DESCRIPTION
This PR removes the `get_transactions` function from `scripts/transition_metrics.py`, and the associated test in `scripts/tests/test_transition_metrics.py`. This function is no longer used in any part of the analysis. This PR closes Issue #132. 