### PR TITLE
Add progress to requirements for testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ jobs:
       - run:
           name: Build Environment
           command: |
-            pip install -r requirements.txt 
-            sudo apt-get update 
+            pip install -r requirements.txt
+            sudo apt-get update
             sudo apt-get install -y \
                   libhdf5-dev \
                   cmake \
@@ -25,6 +25,7 @@ jobs:
                   autoconf \
                   libtool \
                   doxygen \
+                  progress \
                   hdf5-tools
       - run:
           name: Build PyNE
@@ -42,7 +43,7 @@ jobs:
           name: Test transition-scenarios
           command: |
             cd ~/project/scripts/tests/
-            pytest 
+            pytest
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,6 @@ jobs:
                   autoconf \
                   libtool \
                   doxygen \
-                  progress \
                   hdf5-tools
       - run:
           name: Build PyNE

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ tables
 sphinx
 m2r2
 fuzzywuzzy
+progress


### PR DESCRIPTION
As mentioned in #128, the install of PyNE was failing due to a missing package called `progress`. With the error:
```
# PyNE Environment Settings

  export PATH="/home/circleci/.local/bin:${PATH}"
Traceback (most recent call last):
  File "/home/circleci/.local/bin/nuc_data_make", line 4, in <module>
    from pyne.dbgen.nuc_data_make import main
  File "/home/circleci/.local/lib/python3.10/site-packages/pyne/dbgen/nuc_data_make.py", line 4, in <module>
    from pyne.utils import QA_warn
  File "/home/circleci/.local/lib/python3.10/site-packages/pyne/utils.py", line 9, in <module>
    from progress.bar import Bar
ModuleNotFoundError: No module named 'progress'

Exited with code exit status 1
```

This PR adds `progress` to the `requirements.txt` file so the CI will install it for testing. This PR also removes some white space from the `config.yml` file.