### PR TITLE
Add test docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 # Welcome to Transition Scenarios's documentation!
 
 ```{toctree}
-:maxdepth: 1
+:maxdepth: 2
 
 scripts_outline
 analysis_doc
@@ -21,6 +21,12 @@ predicting_the_past_import_doc
 random_lifetime_extension_doc
 transition_metrics_doc
 transition_plots_doc
+test_analysis_doc
+test_create_AR_DeployInst_doc
+test_dataframe_analysis_doc
+test_output_metrics_doc
+test_reactor_deployment_doc
+test_transition_metrics_doc
 ```
 
 # Indices and tables

--- a/docs/test_analysis_doc.rst
+++ b/docs/test_analysis_doc.rst
@@ -1,0 +1,7 @@
+Test Analysis
+-------------
+
+.. automodule:: scripts.tests.test_analysis
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/test_create_AR_DeployInst_doc.rst
+++ b/docs/test_create_AR_DeployInst_doc.rst
@@ -1,0 +1,7 @@
+Test Create AR DeployInst
+-------------------------
+
+.. automodule:: scripts.tests.test_create_AR_DeployInst
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/test_dataframe_analysis_doc.rst
+++ b/docs/test_dataframe_analysis_doc.rst
@@ -1,0 +1,7 @@
+Test Dataframe Analysis
+-----------------------
+
+.. automodule:: scripts.tests.test_dataframe_analysis
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/test_output_metrics_doc.rst
+++ b/docs/test_output_metrics_doc.rst
@@ -1,0 +1,7 @@
+Test Output Metrics
+-------------------
+
+.. automodule:: scripts.tests.test_output_metrics
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/test_reactor_deployment_doc.rst
+++ b/docs/test_reactor_deployment_doc.rst
@@ -1,0 +1,7 @@
+Test Reactor Deployment
+-----------------------
+
+.. automodule:: scripts.tests.test_reactor_deployment
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/test_transition_metrics_doc.rst
+++ b/docs/test_transition_metrics_doc.rst
@@ -1,0 +1,7 @@
+Test Transition Metrics
+-------------------
+
+.. automodule:: scripts.tests.test_transition_metrics
+   :members:
+   :undoc-members:
+   :show-inheritance:


### PR DESCRIPTION
This PR creates test docs for the existing test_scripts in the repository. The style mimics the corresponding script files using autodoc to import the functions automatically into their unique documents.

This PR closes #161 